### PR TITLE
Fix a couple of issues related to the enableTagHelperBundling = false option

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -77,7 +77,14 @@ namespace WebOptimizer.Taghelpers
 
             foreach (string file in sourceFiles)
             {
-                string href = AddFileVersionToPath(file, asset);
+                string fileToAdd = file;
+                if (Path.GetExtension(file) == ".scss")
+                {
+                    if (Path.GetFileName(file).StartsWith("_")) continue;
+
+                    fileToAdd = Path.ChangeExtension(file, "css");
+                }
+                string href = AddFileVersionToPath(fileToAdd, asset);
                 output.PostElement.AppendHtml($"<link href=\"/{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -78,7 +78,7 @@ namespace WebOptimizer.Taghelpers
             foreach (string file in sourceFiles)
             {
                 string href = AddFileVersionToPath(file, asset);
-                output.PostElement.AppendHtml($"<link href=\"{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
+                output.PostElement.AppendHtml($"<link href=\"/{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }
 

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -77,7 +77,7 @@ namespace WebOptimizer.Taghelpers
             foreach (string file in sourceFiles)
             {
                 string src = AddFileVersionToPath(file, asset);
-                output.PostElement.AppendHtml($"<script src=\"{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
+                output.PostElement.AppendHtml($"<script src=\"/{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
             }
         }
     }


### PR DESCRIPTION
In addition to this issues addressed, this does not write out partial scss files ("_*.scss") when the option is selected.  I found that to properly compile partials I had to include them explicitly in the bundle, or subsequent changes would not be picked up in the main file.