### PR TITLE
Configurable Cache Directory and Enable/Disable Memory/Disk caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ Default: **true**
 
 Default: **true**
 
+**enableMemoryCache** determines if the `IMemoryCache` is used for caching.  Can be helpful to disable while in development mode.
+
+Default: **true**
+
+**enableDiskCache** determines if the pipeline assets are cached to disk.  This can speed up application restarts by loading pipline assets from the disk instead of re-executing the pipeline.  Can be helpful to disable while in development mode.
+
+Default: **true**
+
+**cacheDirectory** sets the directory where assets will be stored if `enableDiskCache` is **true**.
+
+Default: `<ContentRootPath>/obj/WebOptimizerCache`
+
 **cdnUrl** is an absolute URL that, if present, is automatically adds a prefix to any script, stylesheet or media file on the page. A Tag Helper adds the prefix automatically when the Tag Helpers have been registered. See how to [register the Tag Helpers here](#tag-helpers).
 
 For example. if the cdnUrl is set to `"http://my-cdn.com"` then script and link tags will prepend the *cdnUrl* to the references. For instance, this script tag:

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -108,8 +108,7 @@ namespace WebOptimizer
                     {
                         throw new FileNotFoundException($"No files found matching \"{sourceFile}\" exist in \"{dir.FullName}\"");
                     }
-                    //files.AddRange(fileMatches.Where(f => !files.Contains(f)));
-                    files.Add(sourceFile);
+                    files.AddRange(fileMatches.Where(f => !files.Contains(f)));
                 }
                 else
                 {

--- a/src/WebOptimizer.Core/AssetResponse.cs
+++ b/src/WebOptimizer.Core/AssetResponse.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace WebOptimizer
 {
@@ -21,96 +18,5 @@ namespace WebOptimizer
         public byte[] Body { get; set; }
 
         public string CacheKey { get; }
-
-        public static bool TryGetFromDiskCache(string route, string cacheKey, string cacheDir, out AssetResponse response)
-        {
-            response = null;
-            string name = CleanRouteName(route);
-            string filePath = GetPath(name, cacheKey, cacheDir);
-
-            if (File.Exists(filePath))
-            {
-                try
-                {
-                    string json = File.ReadAllText(filePath);
-                    response = JsonConvert.DeserializeObject<AssetResponse>(json);
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.Write(ex);
-                    DeleteFileAsync(filePath).GetAwaiter().GetResult();
-                }
-            }
-
-            return response != null;
-        }
-
-        public async Task CacheToDiskAsync(string route, string cacheKey, string cacheDir)
-        {
-            string name = CleanRouteName(route);
-            Directory.CreateDirectory(cacheDir);
-
-            // First delete old cached files
-            IEnumerable<string> oldCachedFiles = Directory.EnumerateFiles(cacheDir, name + "__*.cache");
-
-            foreach (string oldFile in oldCachedFiles)
-            {
-                await DeleteFileAsync(oldFile).ConfigureAwait(false);
-            }
-
-            // Then serialize to disk
-            string filePath = GetPath(name, cacheKey, cacheDir);
-            string json = JsonConvert.SerializeObject(this);
-
-            await WriteFileAsync(filePath, json);
-        }
-
-        private static string CleanRouteName(string route)
-        {
-            return route.Replace('\\', '/').Replace('/', '\''); ;
-        }
-
-        private static string GetPath(string name, string cacheKey, string cacheDir)
-        {
-            return Path.Combine(cacheDir, $"{name}__{cacheKey}.cache");
-        }
-
-        private static async Task DeleteFileAsync(string filePath, int attempts = 5)
-        {
-            await TryAsync(attempts, () =>
-            {
-                File.Delete(filePath);
-                return Task.CompletedTask;
-            }).ConfigureAwait(false);
-        }
-
-        private static async Task WriteFileAsync(string filePath, string content, int attempts = 5)
-        {
-            await TryAsync(attempts, async () =>
-            {
-                using (var writer = new StreamWriter(filePath))
-                {
-                    await writer.WriteAsync(content).ConfigureAwait(false);
-                }
-            }).ConfigureAwait(false);
-        }
-
-        private static async Task TryAsync(int attempts, Func<Task> callback)
-        {
-            try
-            {
-                await callback().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.Write(ex);
-                if (attempts > 0)
-                {
-                    await Task.Delay(10);
-                    attempts--;
-                    await TryAsync(attempts, callback).ConfigureAwait(false);
-                }
-            }
-        }
     }
 }

--- a/src/WebOptimizer.Core/AssetResponseStore.cs
+++ b/src/WebOptimizer.Core/AssetResponseStore.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace WebOptimizer
+{
+    internal class AssetResponseStore : IAssetResponseStore
+    {
+        private readonly ILogger<AssetResponseStore> _logger;
+        private readonly IHostingEnvironment _env;
+        private readonly WebOptimizerOptions _options = new WebOptimizerOptions();
+        private string _cacheDir;
+
+        public AssetResponseStore(ILogger<AssetResponseStore> logger, IHostingEnvironment env, IConfigureOptions<WebOptimizerOptions> options)
+        {
+            _logger = logger;
+            _env = env;
+            options.Configure(_options);
+            _cacheDir = string.IsNullOrWhiteSpace(_options.CacheDirectory)
+                ? Path.Combine(env.ContentRootPath, "obj", "WebOptimizerCache")
+                : _options.CacheDirectory;
+        }
+
+        public async Task AddAsync(string bucket, string cachekey, AssetResponse assetResponse)
+        {
+            string name = CleanName(bucket);
+            Directory.CreateDirectory(_cacheDir);
+
+            // First delete old cached files
+            IEnumerable<string> oldCachedFiles = Directory.EnumerateFiles(_cacheDir, name + "__*.cache");
+            foreach (string oldFile in oldCachedFiles)
+            {
+                await DeleteFileAsync(oldFile).ConfigureAwait(false);
+            }
+
+            // Then serialize to disk
+            string json = JsonConvert.SerializeObject(assetResponse);
+            string filePath = GetPath(bucket, cachekey);
+            await WriteFileAsync(filePath, json).ConfigureAwait(false);
+        }
+
+        public async Task RemoveAsync(string bucket, string cachekey)
+        {
+            string filePath = GetPath(bucket, cachekey);
+            await DeleteFileAsync(filePath);
+        }
+
+        public bool TryGet(string bucket, string cachekey, out AssetResponse assetResponse)
+        {
+            assetResponse = null;
+            string filePath = GetPath(bucket, cachekey);
+
+            if (File.Exists(filePath))
+            {
+                try
+                {
+                    string json = File.ReadAllText(filePath);
+                    assetResponse = JsonConvert.DeserializeObject<AssetResponse>(json);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.Write(ex);
+                    DeleteFileAsync(filePath).GetAwaiter().GetResult();
+                }
+            }
+
+            return assetResponse != null;
+        }
+
+        private string CleanName(string route)
+        {
+            return route.Replace('\\', '/').Replace('/', '\'');
+        }
+
+        private string GetPath(string bucket, string cachekey)
+        {
+            // cachekey is Base64 encoded which uses / as one of the characters.  So for Linux 
+            // we need to clean both the bucket and the cachekey.
+            return Path.Combine(_cacheDir, CleanName($"{bucket}__{cachekey}.cache"));
+        }
+
+        private async Task DeleteFileAsync(string filePath, int attempts = 5)
+        {
+            await TryAsync(attempts, () =>
+            {
+                File.Delete(filePath);
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        }
+
+        private async Task WriteFileAsync(string filePath, string content, int attempts = 5)
+        {
+            await TryAsync(attempts, async () =>
+            {
+                using (var writer = new StreamWriter(filePath))
+                {
+                    await writer.WriteAsync(content).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+
+        private async Task TryAsync(int attempts, Func<Task> callback)
+        {
+            try
+            {
+                await callback().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.Write(ex);
+                if (attempts > 0)
+                {
+                    await Task.Delay(10).ConfigureAwait(false);
+                    attempts--;
+                    await TryAsync(attempts, callback).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/WebOptimizer.Core/Extensions/OptionsExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/OptionsExtensions.cs
@@ -8,7 +8,7 @@ namespace WebOptimizer
         /// <summary>
         /// Ensures that defaults are set
         /// </summary>
-        public static  void EnsureDefaults(this IWebOptimizerOptions options, IHostingEnvironment env)
+        public static void EnsureDefaults(this IWebOptimizerOptions options, IHostingEnvironment env)
         {
             if (env == null)
             {
@@ -16,6 +16,8 @@ namespace WebOptimizer
             }
 
             options.EnableCaching = options.EnableCaching ?? !env.IsDevelopment();
+            options.EnableDiskCache = options.EnableDiskCache ?? !env.IsDevelopment();
+            options.EnableMemoryCache = options.EnableMemoryCache ?? true;
             options.EnableTagHelperBundling = options.EnableTagHelperBundling ?? true;
         }
     }

--- a/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Caching.Memory;
@@ -89,6 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection
             assetPipeline(pipeline);
 
             services.TryAddSingleton<IMemoryCache, MemoryCache>();
+            services.TryAddSingleton<IAssetResponseStore, AssetResponseStore>();
             services.TryAddSingleton<IAssetPipeline>(factory => pipeline);
             services.TryAddSingleton<IAssetBuilder, AssetBuilder>();
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<WebOptimizerOptions>, WebOptimizerConfig>());

--- a/src/WebOptimizer.Core/IAssetResponseStore.cs
+++ b/src/WebOptimizer.Core/IAssetResponseStore.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+
+namespace WebOptimizer
+{
+    internal interface IAssetResponseStore
+    {
+        /// <summary>
+        /// Create or overwrite an entry in the cache.
+        /// </summary>
+        /// <param name="bucket"></param>
+        /// <param name="cachekey"></param>
+        /// <param name="assetResponse">An object identifying the entry.</param>
+        /// <returns><code>true</code> if the entry was created; otherwise <code>false</code>.</returns>
+        Task AddAsync(string bucket, string cachekey, AssetResponse assetResponse);
+
+        /// <summary>
+        /// Remove an entry from the cache.
+        /// </summary>
+        /// <param name="bucket"></param>
+        /// <param name="cachekey"></param>
+        Task RemoveAsync(string bucket, string cachekey);
+
+        /// <summary>
+        /// Gets the <see cref="IAssetResponse"/> associated with <paramref name="cachekey"/> if present.
+        /// </summary>
+        /// <param name="bucket"></param>
+        /// <param name="cachekey">A string identifying the requested entry.</param>
+        /// <param name="assetResponse">The located value or null.</param>
+        /// <returns><code>true</code> if the key was found; otherwise <code>false</code>.</returns>
+        bool TryGet(string bucket, string cachekey, out AssetResponse assetResponse);
+    }
+}

--- a/src/WebOptimizer.Core/IWebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/IWebOptimizerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace WebOptimizer
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace WebOptimizer
 {
     /// <summary>
     /// Options for the Web Optimizer.
@@ -10,6 +12,24 @@
         /// Default is <code>false</code> when running in a development environment.
         /// </summary>
         bool? EnableCaching { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="IMemoryCache"/> based caching is enabled.
+        /// Default is <code>false</code> when running in a development environment.
+        /// </summary>
+        bool? EnableMemoryCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether disk based caching is enabled.
+        /// Default is <code>false</code> when running in a development environment; 
+        /// otherwise the default is <code>true</code>.
+        /// </summary>
+        bool? EnableDiskCache { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory where assets will be stored if <see cref="EnableDiskCache"/> is <code>true</code>.
+        /// </summary>
+        string CacheDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets whether bundling is enabled.

--- a/src/WebOptimizer.Core/WebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/WebOptimizerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace WebOptimizer
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace WebOptimizer
 {
     /// <summary>
     /// Options for the Web Optimizer.
@@ -12,6 +14,19 @@
         public bool? EnableCaching { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether <see cref="IMemoryCache"/> based caching is enabled.
+        /// Default is <code>true</code>.
+        /// </summary>
+        public bool? EnableMemoryCache { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether disk based caching is enabled.
+        /// Default is <code>false</code> when running in a development environment; 
+        /// otherwise the default is <code>true</code>.
+        /// </summary>
+        public bool? EnableDiskCache { get; set; }
+
+        /// <summary>
         /// Gets or sets whether bundling is enabled.
         /// </summary>
         public bool? EnableTagHelperBundling { get; set; }
@@ -20,5 +35,10 @@
         /// Gets the CDN url used for TagHelpers.
         /// </summary>
         public string CdnUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory where assets will be stored if <see cref="EnableDiskCache"/> is <code>true</code>.
+        /// </summary>
+        public string CacheDirectory { get; set; }
     }
 }

--- a/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace WebOptimizer.Core.Test
+{
+    public class AssetBuilderTest
+    {
+        [Fact2]
+        public async Task AssetBuilder_NoMemoryCache()
+        {
+            byte[] cssContent = "*{color:red}".AsByteArray();
+
+            var pipeline = new AssetPipeline();
+            var options = new WebOptimizerOptions() { EnableMemoryCache = false };
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns("/file.css");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
+                 .Returns(Task.FromResult(cssContent));
+
+            StringValues values;
+            var response = new Mock<HttpResponse>().SetupAllProperties();
+            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
+            context.Setup(c => c.Response).Returns(response.Object);
+            context.Setup(c => c.Request.Path).Returns("/file.css");
+
+            var next = new Mock<RequestDelegate>();
+            var env = new Mock<IHostingEnvironment>().SetupAllProperties();
+            env.Setup(e => e.ContentRootPath).Returns(@"D:\Project\");
+
+            object bytes;
+            var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out bytes)).Throws<InvalidOperationException>();
+
+            var store = new Mock<IAssetResponseStore>();
+
+            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
+            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+
+            var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
+            amo.SetupGet(a => a.Value).Returns(options);
+
+            var logger = new Mock<ILogger<AssetBuilder>>();
+            var builder = new AssetBuilder(cache.Object, store.Object, logger.Object, env.Object);
+
+            var result = await builder.BuildAsync(asset.Object, context.Object, options).ConfigureAwait(false);
+
+            Assert.Equal(cssContent, result.Body);
+        }
+
+        [Fact2]
+        public async Task AssetBuilder_NoDiskCache()
+        {
+            byte[] cssContent = "*{color:red}".AsByteArray();
+
+            var pipeline = new AssetPipeline();
+            var options = new WebOptimizerOptions() { EnableDiskCache = false };
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns("/file.css");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
+                 .Returns(Task.FromResult(cssContent));
+
+            StringValues values;
+            var response = new Mock<HttpResponse>().SetupAllProperties();
+            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
+            context.Setup(c => c.Response).Returns(response.Object);
+            context.Setup(c => c.Request.Path).Returns("/file.css");
+
+            var next = new Mock<RequestDelegate>();
+            var env = new Mock<IHostingEnvironment>().SetupAllProperties();
+            env.Setup(e => e.ContentRootPath).Returns(@"D:\Project\");
+
+            var mco = new Mock<IOptions<MemoryCacheOptions>>();
+            mco.SetupGet(o => o.Value).Returns(new MemoryCacheOptions());
+            var cache = new MemoryCache(mco.Object);
+
+            AssetResponse ar;
+            var store = new Mock<IAssetResponseStore>();
+            store.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<string>(), out ar)).Throws<InvalidOperationException>();
+
+            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
+            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+
+            var logger = new Mock<ILogger<AssetBuilder>>();
+            var builder = new AssetBuilder(cache, store.Object, logger.Object, env.Object);
+
+            var result = await builder.BuildAsync(asset.Object, context.Object, options).ConfigureAwait(false);
+
+            Assert.Equal(cssContent, result.Body);
+        }
+
+        [Fact2]
+        public async Task AssetBuilder_NoMemoryCache_and_NoDiskCache()
+        {
+            byte[] cssContent = "*{color:red}".AsByteArray();
+
+            var pipeline = new AssetPipeline();
+            var options = new WebOptimizerOptions() { EnableMemoryCache = false, EnableDiskCache = false };
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns("/file.css");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
+                 .Returns(Task.FromResult(cssContent));
+
+            StringValues values;
+            var response = new Mock<HttpResponse>().SetupAllProperties();
+            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
+            context.Setup(c => c.Response).Returns(response.Object);
+            context.Setup(c => c.Request.Path).Returns("/file.css");
+
+            var next = new Mock<RequestDelegate>();
+            var env = new Mock<IHostingEnvironment>().SetupAllProperties();
+            env.Setup(e => e.ContentRootPath).Returns(@"D:\Project\");
+
+            object bytes;
+            var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out bytes)).Throws<InvalidOperationException>();
+            AssetResponse ar;
+            var store = new Mock<IAssetResponseStore>();
+            store.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<string>(), out ar)).Throws<InvalidOperationException>();
+
+            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
+            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+
+            var logger = new Mock<ILogger<AssetBuilder>>();
+            var builder = new AssetBuilder(cache.Object, store.Object, logger.Object, env.Object);
+
+            var result = await builder.BuildAsync(asset.Object, context.Object, options).ConfigureAwait(false);
+
+            Assert.Equal(cssContent, result.Body);
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/AssetResponseStoreTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetResponseStoreTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace WebOptimizer.Core.Test
+{
+    public class AssetResponseStoreTest
+    {
+        [Fact2]
+        public async Task RoundTrip_Success()
+        {
+            var logger = new Mock<ILogger<AssetResponseStore>>();
+            var env = new Mock<IHostingEnvironment>().SetupAllProperties();
+            env.Setup(e => e.ContentRootPath).Returns(Environment.CurrentDirectory);
+            string path = Path.Combine(Environment.CurrentDirectory, "WebOptimizerTest");
+            string filePath = Path.Combine(path, "bucket__cachekey.cache");
+
+            var woo = new Mock<IConfigureOptions<WebOptimizerOptions>>();
+            woo.Setup(o => o.Configure(It.IsAny<WebOptimizerOptions>()))
+                .Callback<WebOptimizerOptions>(o => o.CacheDirectory = path);
+
+            byte[] body = "*{color:red}".AsByteArray();
+            var before = new AssetResponse(body, "cachekey");
+
+            IAssetResponseStore ars = new AssetResponseStore(logger.Object, env.Object, woo.Object);
+
+            await ars.AddAsync("bucket", "cachekey", before).ConfigureAwait(false);
+            Assert.True(File.Exists(filePath));
+
+            Assert.True(ars.TryGet("bucket", "cachekey", out var after));
+            Assert.Equal(before.CacheKey, after.CacheKey);
+            Assert.Equal(before.Body, after.Body);
+
+            await ars.RemoveAsync("bucket", "cachekey").ConfigureAwait(false);
+
+            Assert.False(File.Exists(filePath));
+        }
+    }
+}


### PR DESCRIPTION
This PR includes the following:

* Refactor `AssetResponse` serialization into `AssetResponseStore`
* Default `AssetResponseStore` uses local disk.  Future improvements could instead use SQL, Redis, etc.
* Add configuration option to disable usage of `IMemoryCache`.  Infrequently helpful during debugging. Defaults to Enabled
* Add configuration option to disable usage of disk cache.  Very useful during development, particularly when the currently generated cachekey is not unique to the pipeline.  See #77.  Defaults to Enabled
* Add configuration option to specify cache directory.  See #74
* Unit tests to cover the above
* Documentation for new configuration settings

I'm new to contributing to OSS and PRs.  Please let me know how I can improve.