### PR TITLE
DynamicConfiguration broken in PR #79

### DIFF
--- a/sample2/WebOptimizer.Core.Sample2/appsettings.json
+++ b/sample2/WebOptimizer.Core.Sample2/appsettings.json
@@ -7,7 +7,11 @@
   },
   "webOptimizer": {
     "enableCaching": true,
-    "enableTagHelperBundling": true
-    //"cdnUrl": "https://my-cdn.com/"
+    "enableMemoryCache": true,
+    "enableDiskCache": true,
+    "cacheDirectory": "/var/temp/weboptimizercache",
+    "enableTagHelperBundling": true,
+    "cdnUrl": "https://my-cdn.com/"
   }
+
 }

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -108,7 +108,11 @@ namespace WebOptimizer
                     {
                         throw new FileNotFoundException($"No files found matching \"{sourceFile}\" exist in \"{dir.FullName}\"");
                     }
-                    files.AddRange(fileMatches.Where(f => !files.Contains(f)));
+
+                    if (!files.Contains(sourceFile))
+                    {
+                        files.Add(sourceFile);
+                    }
                 }
                 else
                 {

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -108,17 +108,12 @@ namespace WebOptimizer
                     {
                         throw new FileNotFoundException($"No files found matching \"{sourceFile}\" exist in \"{dir.FullName}\"");
                     }
-
-                    if (!files.Contains(sourceFile))
-                    {
-                        files.Add(sourceFile);
-                    }
                 }
-                else
+
+                if (!files.Contains(sourceFile))
                 {
                     files.Add(sourceFile);
                 }
-
 
             }
 


### PR DESCRIPTION
PR #79 breaks dynamic configuration - just check example WebOptimizer.Core.Sample2
All tests passes.

In loop from Asset.cs line 92 I have replaced
```
 var matcher = new Matcher();
 matcher.AddInclude(outSourceFile);
...
files.AddRange(fileMatches.Where(f => !files.Contains(f)));
```
by
```
 var matcher = new Matcher();
 matcher.AddInclude(outSourceFile);
...
if (!files.Contains(sourceFile))
{
   files.Add(sourceFile);
}
```
because paths 'outSourceFile'  and 'sourceFile' can be different 

Matcher is created for every single file check and following condition  ensures that one file that is added match
```
if (!fileMatches.Any())
{
   throw new FileNotFoundException($"No files found matching \"{sourceFile}\" exist in \{dir.FullName}\"");
}
```
Following condition prevents duplicates:
```
if (!files.Contains(sourceFile))
{
  files.Add(sourceFile);
}
```
