### PR TITLE
Fixed URL Error When enableTagHelperBundling == false

### DIFF
--- a/sample/appsettings.json
+++ b/sample/appsettings.json
@@ -1,6 +1,6 @@
 {
   "webOptimizer": {
     "enableCaching": false,
-    "enableTagHelperBundling": true
+    "enableTagHelperBundling": false
   }
 }

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -83,7 +83,7 @@ namespace WebOptimizer.Taghelpers
                     fileToAdd = Path.ChangeExtension(file, "css");
                 }
                 string href = AddFileVersionToPath(fileToAdd, asset);
-                output.PostElement.AppendHtml($"<link href=\"/{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
+                output.PostElement.AppendHtml($"<link href=\"{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }
 

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -75,7 +75,7 @@ namespace WebOptimizer.Taghelpers
             foreach (string file in sourceFiles)
             {
                 string src = AddFileVersionToPath(file, asset);
-                output.PostElement.AppendHtml($"<script src=\"/{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
+                output.PostElement.AppendHtml($"<script src=\"{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
             }
         }
     }


### PR DESCRIPTION
When enableTagHelperBundling is false, the tag helper has a conflict with single non-bundled assets. 

To repro, use the updated appsettings.json file (included in this pull request just for repro purposes) to set enableTagHelperBundling to false, and run the WebOptimizer.Core.Sample project. You will see that the Bundle page still works, but the Minification page has broken links to /js/plus.js and /css/a.css.

Expected:
   ```
 <link href="/css/a.css?v=IuRW_uAjSlnLm_ENcFS6O-8R-2AwMZU03mWcB-b4Pf4" rel="stylesheet" />
<script src="/js/plus.js?v=oOwSxme2AgHg0Oy9TD_ZLNzn9OjP3GTCatfkeQW7CGQ" ></script>
```
Actual:
```
<link href="http://css/a.css?v=IuRW_uAjSlnLm_ENcFS6O-8R-2AwMZU03mWcB-b4Pf4" rel="stylesheet" />
<script src="http://js/plus.js?v=oOwSxme2AgHg0Oy9TD_ZLNzn9OjP3GTCatfkeQW7CGQ" ></script>
```

This Pull request fixes the issue, and still allows the multi-file Bundling to function as normal.