### PR TITLE
Use the new IFileVersionProvider

### DIFF
--- a/sample/WebOptimizer.Core.Sample.csproj
+++ b/sample/WebOptimizer.Core.Sample.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-        <PackageReference Include="SharpScss" Version="1.3.8" />
+        <PackageReference Include="Microsoft.AspNetCore.All" />
+        <PackageReference Include="SharpScss" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sample2/WebOptimizer.Core.Sample2/WebOptimizer.Core.Sample2.csproj
+++ b/sample2/WebOptimizer.Core.Sample2/WebOptimizer.Core.Sample2.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -7,7 +7,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +23,7 @@ namespace WebOptimizer
 {
     internal class Asset : IAsset
     {
-        private static FileVersionProvider _fileVersionProvider;
+        private static IFileVersionProvider _fileVersionProvider;
         internal const string PhysicalFilesKey = "PhysicalFiles";
 
         public Asset(string route, string contentType, IAssetPipeline pipeline, IEnumerable<string> sourceFiles)
@@ -171,11 +173,7 @@ namespace WebOptimizer
             if (_fileVersionProvider == null)
             {
                 var cache = (IMemoryCache)context.RequestServices.GetService(typeof(IMemoryCache));
-
-                _fileVersionProvider = new FileVersionProvider(
-                    this.GetFileProvider(env),
-                    cache,
-                    context.Request.PathBase);
+                _fileVersionProvider = context.RequestServices.GetRequiredService<IFileVersionProvider>();
             }
 
             if (!Items.ContainsKey(PhysicalFilesKey))
@@ -191,7 +189,7 @@ namespace WebOptimizer
             {
                 foreach (string file in physicalFiles)
                 {
-                    cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(file));
+                    cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(context.Request.PathBase, file));
                 }
             }
 

--- a/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.TagHelpers.Internal;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WebOptimizer.Taghelpers
 {
@@ -15,7 +15,7 @@ namespace WebOptimizer.Taghelpers
     /// <seealso cref="Microsoft.AspNetCore.Razor.TagHelpers.TagHelper" />
     public abstract class BaseTagHelper : TagHelper
     {
-        private FileVersionProvider _fileProvider;
+        private IFileVersionProvider _fileProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseTagHelper"/> class.
@@ -83,13 +83,10 @@ namespace WebOptimizer.Taghelpers
         {
             if (_fileProvider == null)
             {
-                _fileProvider = new FileVersionProvider(
-                    asset.GetFileProvider(HostingEnvironment),
-                    Cache,
-                    ViewContext.HttpContext.Request.PathBase);
+                _fileProvider = ViewContext.HttpContext.RequestServices.GetRequiredService<IFileVersionProvider>();
             }
 
-            return _fileProvider.AddFileVersionToPath(fileName);
+            return _fileProvider.AddFileVersionToPath(ViewContext.HttpContext.Request.PathBase, fileName);
         }
 
         /// <summary>

--- a/src/WebOptimizer.Core/WebOptimizer.Core.csproj
+++ b/src/WebOptimizer.Core/WebOptimizer.Core.csproj
@@ -21,12 +21,12 @@
 
     <ItemGroup>
         <PackageReference Include="LigerShark.WebOptimizer.Analyzers" Version="1.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
         <PackageReference Include="NUglify" Version="1.5.12" />
     </ItemGroup>
 

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
@@ -37,6 +38,7 @@ namespace WebOptimizer.Test
             var env = new Mock<IHostingEnvironment>();
             var cache = new Mock<IMemoryCache>();
             var fileProvider = new PhysicalFileProvider(Path.GetTempPath());
+            var fileVersionProvider = new Mock<IFileVersionProvider>();
 
             var asset = new Asset(route, contentType, sourcefiles);
             asset.Items.Add("PhysicalFiles", new string[0] );
@@ -51,6 +53,9 @@ namespace WebOptimizer.Test
 
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                    .Returns(cache.Object);
+
+            context.Setup(c => c.RequestServices.GetService(typeof(IFileVersionProvider)))
+                .Returns(fileVersionProvider.Object);
 
             env.Setup(e => e.WebRootFileProvider)
                 .Returns(fileProvider);

--- a/test/WebOptimizer.Core.Test/WebOptimizer.Core.Test.csproj
+++ b/test/WebOptimizer.Core.Test/WebOptimizer.Core.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
FileVersionProvider was renamed and made internal in 2.2. Instead we use IFileVersionProvider and get the implementation from ViewContext.HttpContext.RequestServices.GetRequiredService().

Update to 2.2

Won't work with =< 2.1