### PR TITLE
Switched to IOptionsMonitor due to memory leaks

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
@@ -20,12 +20,12 @@ namespace WebOptimizer.Taghelpers
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseTagHelper"/> class.
         /// </summary>
-        public BaseTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsSnapshot<WebOptimizerOptions> options)
+        public BaseTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsMonitor<WebOptimizerOptions> options)
         {
             HostingEnvironment = env;
             Cache = cache;
             Pipeline = pipeline;
-            Options = options.Value;
+            Options = options.CurrentValue;
         }
 
         /// <summary>

--- a/src/WebOptimizer.Core/Taghelpers/LinkInlineHrefTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkInlineHrefTagHelper.cs
@@ -20,7 +20,7 @@ namespace WebOptimizer.Taghelpers
         /// <summary>
         /// Tag helper for inlining content
         /// </summary>
-        public LinkInlineHrefTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsSnapshot<WebOptimizerOptions> options, IAssetBuilder builder)
+        public LinkInlineHrefTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsMonitor<WebOptimizerOptions> options, IAssetBuilder builder)
             : base(env, cache, pipeline, options)
         {
             _builder = builder;

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -22,7 +22,7 @@ namespace WebOptimizer.Taghelpers
         /// <summary>
         /// Initializes a new instance of the <see cref="LinkTagHelper"/> class.
         /// </summary>
-        public LinkTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsSnapshot<WebOptimizerOptions> options)
+        public LinkTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsMonitor<WebOptimizerOptions> options)
             : base(env, cache, pipeline, options)
         { }
 

--- a/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
@@ -20,7 +20,7 @@ namespace WebOptimizer.Taghelpers
         /// <summary>
         /// Tag helper for inlining content
         /// </summary>
-        public ScriptInlineSrcTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsSnapshot<WebOptimizerOptions> options, IAssetBuilder builder)
+        public ScriptInlineSrcTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsMonitor<WebOptimizerOptions> options, IAssetBuilder builder)
             : base(env, cache, pipeline, options)
         {
             _builder = builder;

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -17,7 +17,7 @@ namespace WebOptimizer.Taghelpers
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptTagHelper"/> class.
         /// </summary>
-        public ScriptTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsSnapshot<WebOptimizerOptions> options)
+        public ScriptTagHelper(IHostingEnvironment env, IMemoryCache cache, IAssetPipeline pipeline, IOptionsMonitor<WebOptimizerOptions> options)
             : base(env, cache, pipeline, options)
         { }
 


### PR DESCRIPTION
I was running into a memory leak. Using dotMemory and disabling things one at a time, I narrowed the problem down to WebOptimizer, then the tag helpers in WebOptimizer, and finally down to the Options parameter.

Switching the options parameter to `IOptionsMonitor` rather than `IOptionsSnapshot` fixed the memory leak. The nature of the memory leak was that each request would leak the view object, viewmodel, controller, and some ASP.NET MVC Core objects relating to the request.

I'm not sure why this was causing the memory leak.