### PR TITLE
Fixed issue due to some File Providers not being able to handle Guid …

### DIFF
--- a/src/WebOptimizer.Core/Processors/Concatenator.cs
+++ b/src/WebOptimizer.Core/Processors/Concatenator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WebOptimizer;
@@ -10,18 +11,23 @@ namespace WebOptimizer
     {
         public override Task ExecuteAsync(IAssetContext context)
         {
-            var sb = new StringBuilder();
-
-            foreach (byte[] bytes in context.Content.Values)
+            // If there is no content, nothing to do
+            if (context.Content.Count > 0)
             {
-                sb.AppendLine(bytes.AsString());
+                var sb = new StringBuilder();
+
+                foreach (byte[] bytes in context.Content.Values)
+                {
+                    sb.AppendLine(bytes.AsString());
+                }
+
+                // Use existing first key as new key to have a valid input for subsequent calls to GetFileInfo
+                var newKey = context.Content.Keys.First();
+                context.Content = new Dictionary<string, byte[]>
+                {
+                    { newKey, sb.ToString().AsByteArray() }
+                };
             }
-
-            context.Content = new Dictionary<string, byte[]>
-            {
-                { Guid.NewGuid().ToString(), sb.ToString().AsByteArray() }
-            };
-
             return Task.CompletedTask;
         }
     }

--- a/src/WebOptimizer.Core/Processors/Concatenator.cs
+++ b/src/WebOptimizer.Core/Processors/Concatenator.cs
@@ -11,23 +11,19 @@ namespace WebOptimizer
     {
         public override Task ExecuteAsync(IAssetContext context)
         {
-            // If there is no content, nothing to do
-            if (context.Content.Count > 0)
+            var sb = new StringBuilder();
+
+            foreach (byte[] bytes in context.Content.Values)
             {
-                var sb = new StringBuilder();
-
-                foreach (byte[] bytes in context.Content.Values)
-                {
-                    sb.AppendLine(bytes.AsString());
-                }
-
-                // Use existing first key as new key to have a valid input for subsequent calls to GetFileInfo
-                var newKey = context.Content.Keys.First();
-                context.Content = new Dictionary<string, byte[]>
-                {
-                    { newKey, sb.ToString().AsByteArray() }
-                };
+                sb.AppendLine(bytes.AsString());
             }
+
+            // Use existing first key as new key to have a valid input for subsequent calls to GetFileInfo or a Guid, if there is no content
+            var newKey = context.Content.Keys.FirstOrDefault() ?? Guid.NewGuid().ToString();
+            context.Content = new Dictionary<string, byte[]>
+            {
+                { newKey, sb.ToString().AsByteArray() }
+            };
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
…keys later in the pipeline

We want to use the library in a Razor Pages Library that contains shared layout, stylesheets and scripts. In this case, the StaticWebAssetsFileProvider is used to access the static content of the library. This FileProvider throws an exception if the key does not start with a slash. 
The fix uses the first key of the concatenated contents instead of generating a Guid so that problems later in the pipeline are circumvented.