### PR TITLE
ExpandGlobs add prefix '/'

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -83,6 +83,7 @@ namespace WebOptimizer.Taghelpers
                     fileToAdd = Path.ChangeExtension(file, "css");
                 }
                 string href = AddFileVersionToPath(fileToAdd, asset);
+                if (!href.StartsWith("/")) href = "/" + href; //dealing with missing prefix "/"
                 output.PostElement.AppendHtml($"<link href=\"{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -75,6 +75,7 @@ namespace WebOptimizer.Taghelpers
             foreach (string file in sourceFiles)
             {
                 string src = AddFileVersionToPath(file, asset);
+                if (!src.StartsWith("/")) src = "/" + src; //dealing with missing prefix "/"
                 output.PostElement.AppendHtml($"<script src=\"{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
             }
         }


### PR DESCRIPTION
following inputFiles + debug mode (no bundling and minification), the output js paths missing prefix "/"!
 {
    "outputFileName": "/lang.min.js",
    "inputFiles": [
      "/i18n/**/*.js"
    ],
    "minify": {
      "enabled": false
    }
  },