### PR TITLE
Fixed RelativePathAdjuster when WebRootFileProvider is a CompositeFileProvider

### DIFF
--- a/src/WebOptimizer.Core/Processors/CssFingerprinter.cs
+++ b/src/WebOptimizer.Core/Processors/CssFingerprinter.cs
@@ -25,9 +25,7 @@ namespace WebOptimizer
             foreach (string key in config.Content.Keys)
             {
                 IFileInfo input = fileProvider.GetFileInfo(key);
-                IFileInfo output = fileProvider.GetFileInfo(config.Asset.Route);
-
-                content[key] = Adjust(config.Content[key].AsString(), input, output, env);
+                content[key] = Adjust(config.Content[key].AsString(), input, env);
             }
 
             config.Content = content;
@@ -35,7 +33,7 @@ namespace WebOptimizer
             return Task.CompletedTask;
         }
 
-        private static byte[] Adjust(string content, IFileInfo input, IFileInfo output, IWebHostEnvironment env)
+        private static byte[] Adjust(string content, IFileInfo input, IWebHostEnvironment env)
         {
             string inputDir = Path.GetDirectoryName(input.PhysicalPath);
 

--- a/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
+++ b/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
 using WebOptimizer;
@@ -24,9 +25,9 @@ namespace WebOptimizer
             foreach (string key in config.Content.Keys)
             {
                 IFileInfo input = fileProvider.GetFileInfo(key);
-                IFileInfo output = fileProvider.GetFileInfo(config.Asset.Route);
+                string outputPath = Path.Combine(env.WebRootPath, config.Asset.Route);
 
-                content[key] = Adjust(config.Content[key].AsString(), input.PhysicalPath, output.PhysicalPath);
+                content[key] = Adjust(config.Content[key].AsString(), input.PhysicalPath, outputPath);
             }
 
             config.Content = content;
@@ -36,8 +37,6 @@ namespace WebOptimizer
 
         private static byte[] Adjust(string cssFileContents, string inputFile, string outputPath)
         {
-            string absoluteOutputPath = new FileInfo(outputPath).FullName;
-
             // apply the RegEx to the file (to change relative paths)
             MatchCollection matches = _rxUrl.Matches(cssFileContents);
 
@@ -61,7 +60,7 @@ namespace WebOptimizer
                     string queryOnly = pathAndQuery.Length == 2 ? pathAndQuery[1] : string.Empty;
 
                     string absolutePath = GetAbsolutePath(cssDirectoryPath, pathOnly);
-                    string serverRelativeUrl = MakeRelative(absoluteOutputPath, absolutePath);
+                    string serverRelativeUrl = MakeRelative(outputPath, absolutePath);
 
                     if (!string.IsNullOrEmpty(queryOnly))
                     {

--- a/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
@@ -25,16 +25,16 @@ namespace WebOptimizer.Test.Processors
             var adjuster = new RelativePathAdjuster();
             var context = new Mock<IAssetContext>().SetupAllProperties();
             var pipeline = new Mock<IAssetPipeline>().SetupAllProperties();
-            var inputFile = new PhysicalFileInfo(new FileInfo(@"c:\source\css\site.css"));
+            var inputFile = new PhysicalFileInfo(new FileInfo(@"//source/css/site.css"));
             var asset = new Mock<IAsset>().SetupAllProperties();
             var env = new Mock<IWebHostEnvironment>();
             var fileProvider = new Mock<IFileProvider>();
 
             env.SetupGet(s => s.WebRootPath)
-                .Returns(@"c:\source");
+                .Returns(@"//source");
 
             context.SetupGet(s => s.Asset.Route)
-                   .Returns("/my/route.css");
+                   .Returns(@"dist/all.css");
 
             context.Setup(s => s.HttpContext.RequestServices.GetService(typeof(IAssetPipeline)))
                    .Returns(pipeline.Object);

--- a/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
@@ -26,10 +26,12 @@ namespace WebOptimizer.Test.Processors
             var context = new Mock<IAssetContext>().SetupAllProperties();
             var pipeline = new Mock<IAssetPipeline>().SetupAllProperties();
             var inputFile = new PhysicalFileInfo(new FileInfo(@"c:\source\css\site.css"));
-            var outputFile = new PhysicalFileInfo(new FileInfo(@"c:\source\dist\all.css"));
             var asset = new Mock<IAsset>().SetupAllProperties();
             var env = new Mock<IWebHostEnvironment>();
             var fileProvider = new Mock<IFileProvider>();
+
+            env.SetupGet(s => s.WebRootPath)
+                .Returns(@"c:\source");
 
             context.SetupGet(s => s.Asset.Route)
                    .Returns("/my/route.css");
@@ -40,15 +42,11 @@ namespace WebOptimizer.Test.Processors
             context.Setup(s => s.HttpContext.RequestServices.GetService(typeof(IWebHostEnvironment)))
                    .Returns(env.Object);
 
-            context.SetupGet(s => s.Asset)
-                   .Returns(asset.Object);
-
             env.SetupGet(e => e.WebRootFileProvider)
                  .Returns(fileProvider.Object);
 
             fileProvider.SetupSequence(f => f.GetFileInfo(It.IsAny<string>()))
-                   .Returns(inputFile)
-                   .Returns(outputFile);
+                   .Returns(inputFile);
 
             context.Object.Content = new Dictionary<string, byte[]> { { "css/site.css", url.AsByteArray() } };
 


### PR DESCRIPTION
Instead of getting a non existing file info for generating an absolute output path, generate the absolute output path using env.WebRootPath + config.Asset.Route.

Full explanation here: 
https://github.com/ligershark/WebOptimizer/issues/109#issuecomment-621709321

The problem can easily be reproduced by adding a reference to a RCL to the AspNetCore project and then attempting add a css/scss bundle to the WebOptimizer pipeline.