### PR TITLE
Fix bug in the EnforceFileExtensions File

### DIFF
--- a/src/WebOptimizer.Core/Processors/EnforceFileExtensions.cs
+++ b/src/WebOptimizer.Core/Processors/EnforceFileExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public static IEnumerable<IAsset> EnforceFileExtensions(this IEnumerable<IAsset> assets, params string[] extensions)
         {
-            return assets.AddProcessor(asset => asset.EnforceFileExtensions());
+            return assets.AddProcessor(asset => asset.EnforceFileExtensions(extensions));
         }
     }
 }


### PR DESCRIPTION
Currently the Enforcement of File Extensions from external sources is failing to register valid pipeline file extensions.