### PR TITLE
Fix relative path url generation

### DIFF
--- a/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
+++ b/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
@@ -25,7 +25,7 @@ namespace WebOptimizer
             foreach (string key in config.Content.Keys)
             {
                 IFileInfo input = fileProvider.GetFileInfo(key);
-                string outputPath = Path.Combine(env.WebRootPath, config.Asset.Route);
+                string outputPath = Path.Combine(env.WebRootPath, config.Asset.Route.TrimStart('/'));
 
                 content[key] = Adjust(config.Content[key].AsString(), input.PhysicalPath, outputPath);
             }

--- a/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
@@ -34,7 +34,7 @@ namespace WebOptimizer.Test.Processors
                 .Returns(@"//source");
 
             context.SetupGet(s => s.Asset.Route)
-                   .Returns(@"dist/all.css");
+                   .Returns(@"/dist/all.css");
 
             context.Setup(s => s.HttpContext.RequestServices.GetService(typeof(IAssetPipeline)))
                    .Returns(pipeline.Object);


### PR DESCRIPTION
All bundle paths seem to end up starting with a "/" which is absolute as far as Path.Combine is concerned. When combining with wwwroot the full path gets lost and the incorrect url gets generated. Removing the '/' at the start of the asset fixes this issue

May address #77, definately addresses a similar issue I have