### PR TITLE
fix issue #73, virtual dir bug on IIS

### DIFF
--- a/src/WebOptimizer.Core/AssetMiddleware.cs
+++ b/src/WebOptimizer.Core/AssetMiddleware.cs
@@ -23,7 +23,12 @@ namespace WebOptimizer
 
         public Task InvokeAsync(HttpContext context, IOptionsSnapshot<WebOptimizerOptions> options)
         {
-            if (_pipeline.TryGetAssetFromRoute(context.Request.Path, out IAsset asset))
+            string path = context.Request.Path.Value;
+
+            if (context.Request.PathBase.HasValue)
+                path = path.TrimStart(context.Request.PathBase.Value.ToCharArray());
+
+            if (_pipeline.TryGetAssetFromRoute(path, out IAsset asset))
             {
                 _logger.LogRequestForAssetStarted(context.Request.Path);
                 return HandleAssetAsync(context, asset, options.Value);


### PR DESCRIPTION
fix the issue  #73  getting the PathBase (virtual dir) from httpContext and remove it from "route" parameter at IAssetPipeline.TryGetAssetFromRoute method  on LinkTagHelper.cs, ScriptTagHelper.cs and AssetMiddleware.cs files.