### PR TITLE
Relative links supports

### DIFF
--- a/src/WebOptimizer.Core/AssetPipeline.cs
+++ b/src/WebOptimizer.Core/AssetPipeline.cs
@@ -147,7 +147,10 @@ namespace WebOptimizer
 
         public static string NormalizeRoute(string route)
         {
-            string cleanRoute = "/" + route.Trim().TrimStart('~', '/');
+            string trimmedRoute = route.Trim();
+            string cleanRoute = trimmedRoute.StartsWith( '/') || trimmedRoute.StartsWith("~")
+                ? "/" + route.Trim().TrimStart('~', '/')
+                : trimmedRoute;
 
             int index = cleanRoute.IndexOfAny(new[] { '?', '#' });
 

--- a/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
@@ -21,7 +21,7 @@ namespace WebOptimizer.Test
         }
 
         [Theory2]
-        [InlineData("route", "/route")]
+        [InlineData("route", "route")]
         [InlineData("/route", "/route")]
         [InlineData("~/route", "/route")]
         [InlineData("~/route ", "/route")]
@@ -122,18 +122,16 @@ namespace WebOptimizer.Test
 
         [Theory2]
         [InlineData("css/*.css", "/css/ost.css")]
-        [InlineData("css/**/*.css", "/css/a/b/c/ost.css")]
         [InlineData("css/**/*.css", "css/a/b/c/ost.css")]
         [InlineData("**/*.css", "/css/a/b/c/ost.css")]
         [InlineData("*.css", "foo.css")]
-        [InlineData("*.css", "/foo.css")]
         public void FromRoute_Globbing_Success(string pattern, string path)
         {
             var pipeline = new AssetPipeline();
             pipeline.AddFiles("text/css", pattern);
 
             Assert.True(pipeline.TryGetAssetFromRoute(path, out var a1));
-            Assert.Equal($"/{path.TrimStart('/')}", a1.Route);
+            Assert.Equal($"{path}", a1.Route);
         }
 
         [Theory2]

--- a/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
@@ -84,6 +84,19 @@ namespace WebOptimizer.Test.Processors
             Assert.Equal(2, asset.SourceFiles.Count());
             Assert.Equal(6, asset.Processors.Count);
         }
+        
+        [Fact2]
+        public void AddCssBundle_DefaultSettings_SuccessRelative()
+        {
+            var pipeline = new AssetPipeline();
+            var asset = pipeline.AddCssBundle("foo.css", "file1.css", "file2.css");
+
+            Assert.Equal("foo.css", asset.Route);
+            Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
+            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(6, asset.Processors.Count);
+        }
+
 
         [Fact2]
         public void AddCssBundle_CustomSettings_Success()
@@ -104,7 +117,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyCssFiles().First();
 
-            Assert.Equal("/**/*.css", asset.Route);
+            Assert.Equal("**/*.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count());
             Assert.True(3 == asset.Processors.Count);

--- a/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
@@ -106,7 +106,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyHtmlFiles().First();
 
-            Assert.Equal("/**/*.html", asset.Route);
+            Assert.Equal("**/*.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count());
             Assert.True(1 == asset.Processors.Count);

--- a/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
@@ -70,6 +70,19 @@ namespace WebOptimizer.Test.Processors
             Assert.Equal(2, asset.SourceFiles.Count());
             Assert.Equal(4, asset.Processors.Count);
         }
+        
+        [Fact2]
+        public void AddJsBundle_DefaultSettings_SuccessRelative()
+        {
+            var pipeline = new AssetPipeline();
+            var asset = pipeline.AddJavaScriptBundle("foo.js", "file1.js", "file2.js");
+
+            Assert.Equal("foo.js", asset.Route);
+            Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
+            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(4, asset.Processors.Count);
+        }
+
 
         [Fact2]
         public void AddJsBundle_CustomSettings_Success()
@@ -90,7 +103,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyJsFiles().First();
 
-            Assert.Equal("/**/*.js", asset.Route);
+            Assert.Equal("**/*.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count());
             Assert.True(2 == asset.Processors.Count);


### PR DESCRIPTION
Currently WebOptimizer transforms all affected by minification/compilation/bundling urls from relative to absolute. As result it breaks page loading if it should be accessed not only from root context. 