### PR TITLE
add option to allow generating bundle with empty content

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ You can control the options from the appsettings.json file.
     "enableDiskCache": true,
     "cacheDirectory": "/var/temp/weboptimizercache",
     "enableTagHelperBundling": true,
-    "cdnUrl": "https://my-cdn.com/"
+    "cdnUrl": "https://my-cdn.com/",
+    "allowEmptyBundle": false
   }
 }
 ```
@@ -267,6 +268,10 @@ Default: `<ContentRootPath>/obj/WebOptimizerCache`
 **cdnUrl** is an absolute URL that, if present, is automatically adds a prefix to any script, stylesheet or media file on the page. A Tag Helper adds the prefix automatically when the Tag Helpers have been registered. See how to [register the Tag Helpers here](#tag-helpers).
 
 For example. if the cdnUrl is set to `"http://my-cdn.com"` then script and link tags will prepend the *cdnUrl* to the references. For instance, this script tag:
+
+**allowEmptyBundle** determines the behavior when there is no content in source file of a bundle, 404 exception will be thrown when the bundle is requested, set to true to get a bundle with empty content instead.
+
+Default: **false**
 
 ```html
 <script src="/js/file.js"></script>

--- a/src/WebOptimizer.Core/AssetBuilder.cs
+++ b/src/WebOptimizer.Core/AssetBuilder.cs
@@ -58,7 +58,7 @@ namespace WebOptimizer
                     response.Headers.Add(name, context.Response.Headers[name]);
                 }
 
-                if (bytes == null || bytes.Length == 0)
+                if (options.AllowEmptyBundle == false && (bytes == null || bytes.Length == 0))
                 {
                     return null;
                 }

--- a/src/WebOptimizer.Core/IWebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/IWebOptimizerOptions.cs
@@ -40,5 +40,10 @@ namespace WebOptimizer
         /// Gets the CDN url used for TagHelpers.
         /// </summary>
         string CdnUrl { get; }
+
+        /// <summary>
+        /// Gets or sets whether empty bundle is allowed to generate instead of throwing an exception
+        /// </summary>
+        public bool? AllowEmptyBundle { get; set; }
     }
 }

--- a/src/WebOptimizer.Core/WebOptimizerConfig.cs
+++ b/src/WebOptimizer.Core/WebOptimizerConfig.cs
@@ -35,7 +35,7 @@ namespace WebOptimizer
             options.CacheDirectory = string.IsNullOrWhiteSpace(options.CacheDirectory)
                 ? Path.Combine(_hostingEnvironment.ContentRootPath, "obj", "WebOptimizerCache")
                 : options.CacheDirectory;
-
+            options.AllowEmptyBundle = options.AllowEmptyBundle ?? false;
         }
     }
 }

--- a/src/WebOptimizer.Core/WebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/WebOptimizerOptions.cs
@@ -40,5 +40,10 @@ namespace WebOptimizer
         /// Gets or sets the directory where assets will be stored if <see cref="EnableDiskCache"/> is <code>true</code>.
         /// </summary>
         public string CacheDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether empty bundle is allowed to generate instead of throwing an exception
+        /// </summary>
+        public bool? AllowEmptyBundle { get; set; }
     }
 }


### PR DESCRIPTION
in some cases, the source files used to generate the bundle just don't contain any content(maybe just comments). Currently, web optimizer would throw 404 exception, add this option for people who want to avoid ugly js errors in browser console log