### PR TITLE
Fix concurrency issue when registering assets in AssetPipeline

### DIFF
--- a/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -47,8 +48,8 @@ namespace WebOptimizer.Core.Test
 
             var store = new Mock<IAssetResponseStore>();
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
             amo.SetupGet(a => a.Value).Returns(options);
@@ -95,8 +96,8 @@ namespace WebOptimizer.Core.Test
             var store = new Mock<IAssetResponseStore>();
             store.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<string>(), out ar)).Throws<InvalidOperationException>();
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var logger = new Mock<ILogger<AssetBuilder>>();
             var builder = new AssetBuilder(cache, store.Object, logger.Object, env.Object);
@@ -139,8 +140,8 @@ namespace WebOptimizer.Core.Test
             var store = new Mock<IAssetResponseStore>();
             store.Setup(s => s.TryGet(It.IsAny<string>(), It.IsAny<string>(), out ar)).Throws<InvalidOperationException>();
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var logger = new Mock<ILogger<AssetBuilder>>();
             var builder = new AssetBuilder(cache.Object, store.Object, logger.Object, env.Object);

--- a/test/WebOptimizer.Core.Test/AssetMiddlewareTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetMiddlewareTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -45,8 +46,8 @@ namespace WebOptimizer.Test
             var env = new HostingEnvironment();
             var cache = new Mock<IMemoryCache>();
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
             amo.SetupGet(a => a.Value).Returns(options);
@@ -91,8 +92,8 @@ namespace WebOptimizer.Test
             var env = new HostingEnvironment();
             var cache = new Mock<IMemoryCache>();
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
             amo.SetupGet(a => a.Value).Returns(options);
@@ -140,8 +141,8 @@ namespace WebOptimizer.Test
             cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out bytes))
                  .Returns(true);
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
             amo.SetupGet(a => a.Value).Returns(options);
@@ -198,8 +199,8 @@ namespace WebOptimizer.Test
             cache.Setup(c => c.TryGetValue(It.IsAny<string>(), out bytes))
                  .Returns(true);
 
-            var member = pipeline.GetType().GetField("_assets", BindingFlags.NonPublic | BindingFlags.Instance);
-            member.SetValue(pipeline, new List<IAsset> { asset.Object });
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+            pipeline._assets.TryAdd(asset.Object.Route, asset.Object);
 
             var amo = new Mock<IOptionsSnapshot<WebOptimizerOptions>>();
             amo.SetupGet(a => a.Value).Returns(options);

--- a/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NUglify.Helpers;
 using Xunit;
@@ -164,6 +166,20 @@ namespace WebOptimizer.Test
             Assert.Equal(1, a1.Processors.Count);
         }
 
+        [Fact2]
+        public void TryGetAssetFromRoute_Concurrency()
+        {
+            var pipeline = new AssetPipeline();
+            pipeline._assets = new ConcurrentDictionary<string, IAsset>();
+
+            pipeline._assets.TryAdd("/**/*.less", new Asset("/**/*.less", "text/css; charset=UFT-8", new [] { "**/*.less" }));
+            pipeline._assets.TryAdd("/**/*.css", new Asset("/**/*.css", "text/css; charset=UFT-8", new [] { "**/*.css" }));
+
+            Parallel.For(0, 100, iteration =>
+            {
+                pipeline.TryGetAssetFromRoute($"/some_file{iteration}.less", out var a1);
+            });
+        }
 
         [Fact2]
         public void FromRoute_Null_Success()


### PR DESCRIPTION
fixes #66

Because HTTP server can accept multiple requests at the same time we can end up iterating assets concurrently and causing `System.InvalidOperationException: Collection was modified; enumeration operation may not execute.` and it's probably also possible to create invalid state (duplicates).

Switching to `ConcurrentDictionary` which protects from concurrent writes and also adds indexer to get route directly.