### PR TITLE
Incorrect usage of TrimStart-method generating wrong paths when PathBase exists

### DIFF
--- a/src/WebOptimizer.Core/AssetMiddleware.cs
+++ b/src/WebOptimizer.Core/AssetMiddleware.cs
@@ -26,7 +26,13 @@ namespace WebOptimizer
             string path = context.Request.Path.Value;
 
             if (context.Request.PathBase.HasValue)
-                path = path.TrimStart(context.Request.PathBase.Value.ToCharArray());
+            {
+                string pathBase = context.Request.PathBase.Value;
+                if (path.StartsWith(pathBase))
+                {
+                    path = path.Substring(pathBase.Length);
+                }
+            }                
 
             if (_pipeline.TryGetAssetFromRoute(path, out IAsset asset))
             {

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -34,7 +34,7 @@ namespace WebOptimizer.Taghelpers
         [HtmlAttributeNotBound]
         [ViewContext]
         public ViewContext CurrentViewContext { get; set; }
-        
+
         /// <summary>
         /// Synchronously executes the TagHelper
         /// </summary>
@@ -46,19 +46,22 @@ namespace WebOptimizer.Taghelpers
             }
 
             string href = GetValue("href", output);
-            
-              if (CurrentViewContext.HttpContext.Request.PathBase.HasValue)
-                href = href.TrimStart(CurrentViewContext.HttpContext.Request.PathBase.Value.ToCharArray());
+            string pathBase = null;
+            if (CurrentViewContext.HttpContext.Request.PathBase.HasValue )
+            {
+                pathBase = CurrentViewContext.HttpContext.Request.PathBase.Value;
+            }
+
+            if (pathBase != null && href.StartsWith(pathBase))
+            {
+                href = href.Substring(pathBase.Length);
+            }                
 
             if (Pipeline.TryGetAssetFromRoute(href, out IAsset asset) && !output.Attributes.ContainsName("inline"))
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                     if (CurrentViewContext.HttpContext.Request.PathBase.HasValue)
-                        href = CurrentViewContext.HttpContext.Request.PathBase.Value + GenerateHash(asset);
-                    else
-                        href = GenerateHash(asset);
-
+                    href = $"{pathBase}{GenerateHash(asset)}";
                     output.Attributes.SetAttribute("href", href);
                 }
                 else

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -44,19 +45,24 @@ namespace WebOptimizer.Taghelpers
 
             if (string.IsNullOrEmpty(src))
                 return;
+
+            string pathBase = null;
                 
             if (CurrentViewContext.HttpContext.Request.PathBase.HasValue)
-                src = src.TrimStart(CurrentViewContext.HttpContext.Request.PathBase.Value.ToCharArray());
+            {
+                pathBase = CurrentViewContext.HttpContext.Request.PathBase.Value;
+            }
+
+            if (pathBase != null && src.StartsWith(pathBase))
+            {
+                src = src.Substring(pathBase.Length);
+            }               
 
             if (Pipeline.TryGetAssetFromRoute(src, out IAsset asset) && !output.Attributes.ContainsName("inline"))
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                    if (CurrentViewContext.HttpContext.Request.PathBase.HasValue)
-                        src = CurrentViewContext.HttpContext.Request.PathBase.Value + GenerateHash(asset);
-                    else
-                        src = GenerateHash(asset);
-
+                    src = $"{pathBase}{GenerateHash(asset)}";
                     output.Attributes.SetAttribute("src", src);
                 }
                 else


### PR DESCRIPTION
Fixed incorrect usage of TrimStart-method which resulted in wrong paths to resources in certain situations. For example if PathBase was "/someapp" and you tried to serve asset from "/somepath/site.css" the wrong usage of TrimStart resulted to string "th/site.css" since it removed all characters (Value.ToCharArray()) that existed in PathBase.