### PR TITLE
Support compression of returned content when served via HTTPS 

### DIFF
--- a/sample2/WebOptimizer.Core.Sample2/Properties/launchSettings.json
+++ b/sample2/WebOptimizer.Core.Sample2/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:62609/"
+      "applicationUrl": "http://localhost:62609/;https://localhost:62610/"
     }
   }
 }

--- a/sample2/WebOptimizer.Core.Sample2/Startup.cs
+++ b/sample2/WebOptimizer.Core.Sample2/Startup.cs
@@ -24,7 +24,7 @@ namespace WebOptimizer.Core.Sample2
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
-
+            services.AddResponseCompression();
 
             var cssSettings = new CssBundlingSettings();
             var codeSettings = new CodeBundlingSettings
@@ -47,9 +47,11 @@ namespace WebOptimizer.Core.Sample2
                 app.UseExceptionHandler("/Home/Error");
             }
 
+            app.UseResponseCompression();
+
             const string scriptsPath1 = "Scripts1";
             const string scriptsPath2 = "Scripts2";
-            
+
             var currentDirectory = Directory.GetCurrentDirectory();
             app.UseWebOptimizer(HostingEnvironment, new[]
             {
@@ -69,7 +71,7 @@ namespace WebOptimizer.Core.Sample2
                     FileProvider = new EmbeddedFileProvider(Lib.AssemblyTools.GetCurrentAssembly()),
                 }
             });
-            
+
             app.UseStaticFiles();
 
             app.UseRouting();

--- a/src/WebOptimizer.Core/AssetMiddleware.cs
+++ b/src/WebOptimizer.Core/AssetMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -106,7 +107,18 @@ namespace WebOptimizer
 
             if (cachedResponse?.Body?.Length > 0)
             {
+                SetCompressionMode(context, options);
                 await context.Response.Body.WriteAsync(cachedResponse.Body, 0, cachedResponse.Body.Length);
+            }
+        }
+
+        // Only called when we expect to serve the body.
+        private static void SetCompressionMode(HttpContext context, IWebOptimizerOptions options)
+        {
+            IHttpsCompressionFeature responseCompressionFeature = context.Features.Get<IHttpsCompressionFeature>();
+            if (responseCompressionFeature != null)
+            {
+                responseCompressionFeature.Mode = options.HttpsCompression;
             }
         }
     }

--- a/src/WebOptimizer.Core/IWebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/IWebOptimizerOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace WebOptimizer
 {
@@ -45,5 +46,14 @@ namespace WebOptimizer
         /// Gets or sets whether empty bundle is allowed to generate instead of throwing an exception
         /// </summary>
         public bool? AllowEmptyBundle { get; set; }
+
+        /// <summary>
+        /// Indicates if files should be compressed for HTTPS requests when the Response Compression middleware is available.
+        /// The default value is <see cref="HttpsCompressionMode.Compress"/>.
+        /// </summary>
+        /// <remarks>
+        /// Enabling compression on HTTPS requests for remotely manipulable content may expose security problems.
+        /// </remarks>
+        HttpsCompressionMode HttpsCompression { get; set; }
     }
 }

--- a/src/WebOptimizer.Core/WebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/WebOptimizerOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace WebOptimizer
 {
@@ -45,5 +46,14 @@ namespace WebOptimizer
         /// Gets or sets whether empty bundle is allowed to generate instead of throwing an exception
         /// </summary>
         public bool? AllowEmptyBundle { get; set; }
+
+        /// <summary>
+        /// Indicates if files should be compressed for HTTPS requests when the Response Compression middleware is available.
+        /// The default value is <see cref="HttpsCompressionMode.Compress"/>.
+        /// </summary>
+        /// <remarks>
+        /// Enabling compression on HTTPS requests for remotely manipulable content may expose security problems.
+        /// </remarks>
+        public HttpsCompressionMode HttpsCompression { get; set; } = HttpsCompressionMode.Compress;
     }
 }


### PR DESCRIPTION
When serving static files the `StaticFileMiddleware` sets HTTPS compression allowed by default as it's static content and not affected of CRIME/BREACH attacks which rely on attacker modifying returned payload. As `AssetMiddleware` basically can be compared to `StaticFileMiddleware`it makes sense to allow the same logic for response compression.

I've adapted the approach `StaticFileMiddleware` uses and now also WebOptimizer content is compressed when served via HTTPS. The configuration option defaults and is documented the same way as `StaticFileMiddleware` version.