### PR TITLE
Handling non-existent static content files

### DIFF
--- a/src/WebOptimizer.Core/AssetBuilder.cs
+++ b/src/WebOptimizer.Core/AssetBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -34,7 +35,16 @@ namespace WebOptimizer
         /// </summary>
         public async Task<IAssetResponse> BuildAsync(IAsset asset, HttpContext context, IWebOptimizerOptions options)
         {
-            string cacheKey = asset.GenerateCacheKey(context);
+            string cacheKey;
+            try
+            {
+                cacheKey = asset.GenerateCacheKey(context);
+            }
+            catch (FileNotFoundException)
+            {
+                _logger.LogFileNotFound(context.Request.Path);
+                return null;
+            }
 
             if (options.EnableMemoryCache == true && _cache.TryGetValue(cacheKey, out AssetResponse value))
             {

--- a/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
@@ -25,7 +25,11 @@ namespace WebOptimizer
             logLevel: LogLevel.Information,
             eventId: 1004,
             formatString: "No response generated for '{Path}'. Passing on to next middleware.");
-
+        private static Action<ILogger, string, Exception> _logFileNotFound = LoggerMessage.Define<string>(
+            logLevel: LogLevel.Warning,
+            eventId: 1005,
+            formatString: "File '{Path}' not found. Passing on to next middleware.");
+        
         public static void LogRequestForAssetStarted(this ILogger logger, string path) =>
             _logRequestForAssetStarted(logger, path, null);
 
@@ -40,5 +44,8 @@ namespace WebOptimizer
 
         public static void LogZeroByteResponse(this ILogger logger, string path) =>
             _logZeroByteResponse(logger, path, null);
+        
+        public static void LogFileNotFound(this ILogger logger, string path) =>
+            _logFileNotFound(logger, path, null);
     }
 }


### PR DESCRIPTION
This fixes #102

Added FileNotFound exception handling (originally reported in #102) to pass execution to next middleware. Tested locally and can see 404 coming back 
![image](https://user-images.githubusercontent.com/7429027/119358871-ef450800-bca0-11eb-9c93-c9cf35b3ba97.png)
![image](https://user-images.githubusercontent.com/7429027/119358921-fb30ca00-bca0-11eb-8761-f3ba9279025f.png)
