### PR TITLE
Replace static FileVersionProvider with new instance

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -20,7 +20,6 @@ namespace WebOptimizer
 {
     internal class Asset : IAsset
     {
-        private static FileVersionProvider _fileVersionProvider;
         internal const string PhysicalFilesKey = "PhysicalFiles";
 
         public Asset(string route, string contentType, IAssetPipeline pipeline, IEnumerable<string> sourceFiles)
@@ -176,16 +175,12 @@ namespace WebOptimizer
 
             IEnumerable<string> physicalFiles;
             var env = (IWebHostEnvironment)context.RequestServices.GetService(typeof(IWebHostEnvironment));
+            var cache = (IMemoryCache)context.RequestServices.GetService(typeof(IMemoryCache));
 
-            if (_fileVersionProvider == null)
-            {
-                var cache = (IMemoryCache)context.RequestServices.GetService(typeof(IMemoryCache));
-
-                _fileVersionProvider = new FileVersionProvider(
-                    this.GetFileProvider(env),
-                    cache,
-                    context.Request.PathBase);
-            }
+            var fileVersionProvider = new FileVersionProvider(
+                this.GetFileProvider(env),
+                cache,
+                context.Request.PathBase);
 
             if (!Items.ContainsKey(PhysicalFilesKey))
             {
@@ -200,7 +195,7 @@ namespace WebOptimizer
             {
                 foreach (string file in physicalFiles)
                 {
-                    cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(file));
+                    cacheKey.Append(fileVersionProvider.AddFileVersionToPath(file));
                 }
             }
 


### PR DESCRIPTION
While running our test  suite with `WebApplicationFactory`, we saw sporadic errors from time to time when other test case completed and other one was still running:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.Extensions.Caching.Memory.MemoryCache'.
   at Microsoft.Extensions.Caching.Memory.MemoryCache.CheckDisposed()
   at Microsoft.Extensions.Caching.Memory.MemoryCache.TryGetValue(Object key, Object& result)
   at Microsoft.Extensions.Caching.Memory.CacheExtensions.TryGetValue[TItem](IMemoryCache cache, Object key, TItem& value)
   at WebOptimizer.FileVersionProvider.AddFileVersionToPath(String path)
   at WebOptimizer.Asset.GenerateCacheKey(HttpContext context)
   at WebOptimizer.Taghelpers.BaseTagHelper.GenerateHash(IAsset asset)
   at WebOptimizer.Taghelpers.LinkTagHelper.Process(TagHelperContext context, TagHelperOutput output)
   at Microsoft.AspNetCore.Razor.TagHelpers.TagHelper.ProcessAsync(TagHelperContext context, TagHelperOutput output)
   at Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner.RunAsync(TagHelperExecutionContext executionContext)
```

We tracked this down to a shared static field that can keep reference to a disposed `IMemoryCache`. The instantiation seems to be pretty cheap compared to everything else going on so replacing static field with always new'ing the instance. 