### PR TITLE
Fix for #197

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -48,7 +48,7 @@ namespace WebOptimizer.Taghelpers
             string href = GetValue("href", output);
             string pathBase = CurrentViewContext.HttpContext?.Request?.PathBase.Value;
 
-            if (pathBase != null && href.StartsWith(pathBase))
+            if (!string.IsNullOrEmpty(pathBase) && href.StartsWith(pathBase))
             {
                 href = href.Substring(pathBase.Length);
             }                


### PR DESCRIPTION
Fixes #197 as the previous `HasValue` was a full check, but not Value might not be null but might be an empty string thus passing the condition and failing on the href condition check.  This simply checks if either null or empty string, getting back to the 'null' behavior.