### PR TITLE
Make glob expansion respect rooted paths

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -113,6 +113,12 @@ namespace WebOptimizer
 
                         IEnumerable<string> fileMatches = globbingResult.Files.Select(f => f.Path);
 
+                        var sourceIsRooted = outSourceFile.StartsWith('/');
+                        if(sourceIsRooted)
+                        {
+                            fileMatches = fileMatches.Select(f => "/" + f);
+                        }
+
                         if (!fileMatches.Any())
                         {
                             continue;


### PR DESCRIPTION
Fixes #136, fixes #199. See also discussion in #118.

As suggested [here](https://github.com/ligershark/WebOptimizer/pull/118#issuecomment-854477942), this change checks whether the source file glob has a `'/'` prefix and if so, prepends it to the files matched in `ExpandGlob`.

Given this setup:
```csharp
pipeline.AddCssBundle("/css/bundle.css", "css/*.css", "/morecss/**/*.css");
```
Current markup (paths are always relative):
```html
<link href="css/a.css" rel="stylesheet">
<link href="css/b.css" rel="stylesheet">
<link href="morecss/c.css" rel="stylesheet">
<link href="morecss/foo/d.css" rel="stylesheet">
```
Markup with this change (paths follow the source pattern):
```html
<link href="css/a.css" rel="stylesheet">
<link href="css/b.css" rel="stylesheet">
<link href="/morecss/c.css" rel="stylesheet">
<link href="/morecss/foo/d.css" rel="stylesheet">
```