### PR TITLE
Removed unnecessary check

### DIFF
--- a/src/WebOptimizer.Core/AssetPipeline.cs
+++ b/src/WebOptimizer.Core/AssetPipeline.cs
@@ -113,11 +113,6 @@ namespace WebOptimizer
 
             route = NormalizeRoute(route);
 
-            if (Assets.Any(a => a.Route.Equals(route, StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new ArgumentException($"The route \"{route}\" was already specified", nameof(route));
-            }
-
             IAsset asset = new Asset(route, contentType, this, sourceFiles);
             _assets.TryAdd(route, asset);
 

--- a/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
@@ -52,16 +52,16 @@ namespace WebOptimizer.Test
         }
 
         [Fact2]
-        public void AddTwoSameRoutes_Throws()
+        public void AddTwoSameRoutes_Ignore()
         {
             var env = new HostingEnvironment { EnvironmentName = "Development" };
-            var asset1 = new Asset("/route", "text/css", new[] { "file.css" });
-            var asset2 = new Asset("/route", "text/css", new[] { "file.css" });
+            var route = "/route";
+            var asset1 = new Asset(route, "text/css", new[] { "file.css" });
+            var asset2 = new Asset(route, "text/css", new[] { "file.css" });
             var pipeline = new AssetPipeline();
 
-            var ex = Assert.Throws<ArgumentException>(() => pipeline.AddBundle(new[] { asset1, asset2 }));
+            pipeline.AddBundle(new[] { asset1, asset2 });
 
-            Assert.Equal("route", ex.ParamName);
             Assert.Equal(1, pipeline.Assets.Count);
         }
 


### PR DESCRIPTION
Here #141 was introduced concurrent registering of assets, so this check is no longer needed. And this is throwing an unnecessary exception at the moment.
https://github.com/nopSolutions/nopCommerce/issues/5994