### PR TITLE
Added API to append sources to the asset at runtime.

### DIFF
--- a/src/WebOptimizer.Core/IAsset.cs
+++ b/src/WebOptimizer.Core/IAsset.cs
@@ -37,7 +37,7 @@ namespace WebOptimizer
         /// <summary>
         /// Gets the webroot relative source files.
         /// </summary>
-        IEnumerable<string> SourceFiles { get; }
+        HashSet<string> SourceFiles { get; }
 
         /// <summary>
         /// Executes the processors and returns the modified content.
@@ -48,5 +48,11 @@ namespace WebOptimizer
         /// Gets the cache key associated with this version of the asset.
         /// </summary>
         string GenerateCacheKey(HttpContext context);
+
+        /// <summary>
+        /// Adds a source file to the asset
+        /// </summary>
+        /// <param name="route">Relative path of a source file</param>
+        void TryAddSourceFile(string route);
     }
 }

--- a/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
@@ -71,6 +71,7 @@ namespace WebOptimizer.Core.Test
             var pipeline = new AssetPipeline();
             var options = new WebOptimizerOptions() { EnableDiskCache = false };
             var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>());
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
@@ -116,6 +117,7 @@ namespace WebOptimizer.Core.Test
             var pipeline = new AssetPipeline();
             var options = new WebOptimizerOptions() { EnableMemoryCache = false, EnableDiskCache = false };
             var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>());
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");

--- a/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
@@ -81,10 +81,10 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(6, asset.Processors.Count);
         }
-        
+
         [Fact2]
         public void AddCssBundle_DefaultSettings_SuccessRelative()
         {
@@ -93,10 +93,9 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("foo.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(6, asset.Processors.Count);
         }
-
 
         [Fact2]
         public void AddCssBundle_CustomSettings_Success()
@@ -107,7 +106,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(6, asset.Processors.Count);
         }
 
@@ -119,7 +118,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("**/*.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count());
+            Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(3 == asset.Processors.Count);
         }
     }

--- a/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
@@ -83,7 +83,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(3, asset.Processors.Count);
         }
 
@@ -96,7 +96,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(3, asset.Processors.Count);
         }
 
@@ -108,7 +108,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("**/*.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count());
+            Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(1 == asset.Processors.Count);
         }
     }

--- a/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
@@ -67,7 +67,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(4, asset.Processors.Count);
         }
         
@@ -79,7 +79,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("foo.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(4, asset.Processors.Count);
         }
 
@@ -93,7 +93,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/foo.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
-            Assert.Equal(2, asset.SourceFiles.Count());
+            Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(4, asset.Processors.Count);
         }
 
@@ -105,7 +105,7 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("**/*.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count());
+            Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(2 == asset.Processors.Count);
         }
     }


### PR DESCRIPTION
Sometimes we need to add files to the bundle at runtime (e.g., by a condition in Razor markup). At now, if we're trying to add a file, the bundle won't be updated until the clear cache.