### PR TITLE
Pass the AssetConfig and required components down

### DIFF
--- a/sample/Plugins/SassCompiler.cs
+++ b/sample/Plugins/SassCompiler.cs
@@ -18,7 +18,7 @@ namespace WebOptimizerDemo
         /// <summary>
         /// Gets the custom key that should be used when calculating the memory cache key.
         /// </summary>
-        public string CacheKey(HttpContext context) => string.Empty;
+        public string CacheKey(HttpContext context, IAssetContext config) => string.Empty;
 
         /// <summary>
         /// Executes the processor on the specified configuration.

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -157,8 +157,10 @@ namespace WebOptimizer
             return file.LastModified.UtcDateTime;
         }
 
-        public string GenerateCacheKey(HttpContext context)
+        public string GenerateCacheKey(HttpContext context, IWebOptimizerOptions options)
         {
+            var config = new AssetContext(context, this, options);
+            
             var cacheKey = new StringBuilder(Route);
 
             if (context.Request.Headers.TryGetValue("Accept-Encoding", out StringValues enc))
@@ -196,7 +198,7 @@ namespace WebOptimizer
             {
                 try
                 {
-                    cacheKey.Append(processors.CacheKey(context) ?? string.Empty);
+                    cacheKey.Append(processors.CacheKey(context, config) ?? string.Empty);
                 }
                 catch (Exception ex)
                 {

--- a/src/WebOptimizer.Core/AssetBuilder.cs
+++ b/src/WebOptimizer.Core/AssetBuilder.cs
@@ -38,7 +38,7 @@ namespace WebOptimizer
             string cacheKey;
             try
             {
-                cacheKey = asset.GenerateCacheKey(context);
+                cacheKey = asset.GenerateCacheKey(context, options);
             }
             catch (FileNotFoundException)
             {

--- a/src/WebOptimizer.Core/IAsset.cs
+++ b/src/WebOptimizer.Core/IAsset.cs
@@ -47,7 +47,7 @@ namespace WebOptimizer
         /// <summary>
         /// Gets the cache key associated with this version of the asset.
         /// </summary>
-        string GenerateCacheKey(HttpContext context);
+        string GenerateCacheKey(HttpContext context, IWebOptimizerOptions options);
 
         /// <summary>
         /// Adds a source file to the asset

--- a/src/WebOptimizer.Core/Processors/IProcessor.cs
+++ b/src/WebOptimizer.Core/Processors/IProcessor.cs
@@ -16,6 +16,6 @@ namespace WebOptimizer
         /// <summary>
         /// Gets the custom key that should be used when calculating the memory cache key.
         /// </summary>
-        string CacheKey(HttpContext context);
+        string CacheKey(HttpContext context, IAssetContext config);
     }
 }

--- a/src/WebOptimizer.Core/Processors/Processor.cs
+++ b/src/WebOptimizer.Core/Processors/Processor.cs
@@ -17,7 +17,7 @@ namespace WebOptimizer
         /// <summary>
         /// Gets the custom key that should be used when calculating the memory cache key.
         /// </summary>
-        public virtual string CacheKey(HttpContext context) => string.Empty;
+        public virtual string CacheKey(HttpContext context, IAssetContext config) => string.Empty;
 
         /// <summary>
         /// Executes the processor on the specified configuration.

--- a/src/WebOptimizer.Core/TagHelpersDynamic/Helpers.cs
+++ b/src/WebOptimizer.Core/TagHelpersDynamic/Helpers.cs
@@ -111,9 +111,9 @@ namespace WebOptimizer.TagHelpersDynamic
         /// Generates a hash of the files in the bundle.
         /// /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string GenerateHash(IAsset asset, HttpContext httpContext)
+        private static string GenerateHash(IAsset asset, HttpContext httpContext, IWebOptimizerOptions options)
         {
-            string hash = asset.GenerateCacheKey(httpContext);
+            string hash = asset.GenerateCacheKey(httpContext, options);
 
             return $"{asset.Route}?v={hash}";
         }
@@ -158,7 +158,7 @@ namespace WebOptimizer.TagHelpersDynamic
 
                 string pathBase = actionContext.HttpContext?.Request?.PathBase.Value;
 
-                output.Attributes.SetAttribute(attrName, $"{pathBase}{GenerateHash(assetItem, actionContext.HttpContext)}");
+                output.Attributes.SetAttribute(attrName, $"{pathBase}{GenerateHash(assetItem, actionContext.HttpContext, options)}");
 
                 return true;
             }

--- a/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
@@ -96,7 +96,7 @@ namespace WebOptimizer.Taghelpers
         /// </summary>
         protected string GenerateHash(IAsset asset)
         {
-            string hash = asset.GenerateCacheKey(ViewContext.HttpContext);
+            string hash = asset.GenerateCacheKey(ViewContext.HttpContext, Options);
 
             return $"{asset.Route}?v={hash}";
         }

--- a/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
@@ -27,7 +27,7 @@ namespace WebOptimizer.Core.Test
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
-            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("cachekey");
             asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
                  .Returns(Task.FromResult(cssContent));
 
@@ -74,7 +74,7 @@ namespace WebOptimizer.Core.Test
             asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>());
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
-            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("cachekey");
             asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
                  .Returns(Task.FromResult(cssContent));
 
@@ -120,7 +120,7 @@ namespace WebOptimizer.Core.Test
             asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>());
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
-            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("cachekey");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("cachekey");
             asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
                  .Returns(Task.FromResult(cssContent));
 
@@ -159,7 +159,7 @@ namespace WebOptimizer.Core.Test
         {
             var options = new WebOptimizerOptions();
             var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Throws<FileNotFoundException>();
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Throws<FileNotFoundException>();
             
             
             StringValues values;

--- a/test/WebOptimizer.Core.Test/AssetMiddlewareTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetMiddlewareTest.cs
@@ -173,7 +173,7 @@ namespace WebOptimizer.Test
             asset.SetupGet(a => a.Route).Returns("/file.css");
             asset.Setup(a => a.ExecuteAsync(It.IsAny<HttpContext>(), options))
                  .Returns(Task.FromResult(cssContent));
-            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>())).Returns("etag");
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("etag");
 
             StringValues values = "etag";
             var response = new Mock<HttpResponse>().SetupAllProperties();

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -34,6 +34,7 @@ namespace WebOptimizer.Test
             string contentType = "text/css";
             var sourcefiles = new[] { "file1.css" };
             var context = new Mock<HttpContext>().SetupAllProperties();
+            var options = new WebOptimizerOptions() { EnableCaching = true };
             var env = new Mock<IWebHostEnvironment>();
             var cache = new Mock<IMemoryCache>();
             var fileProvider = new PhysicalFileProvider(Path.GetTempPath());
@@ -56,11 +57,11 @@ namespace WebOptimizer.Test
                 .Returns(fileProvider);
 
             // Check non-gzip value
-            string key = asset.GenerateCacheKey(context.Object);
+            string key = asset.GenerateCacheKey(context.Object, options);
             Assert.Equal("_BZuuBNh_zEXnNPIPaO_4Ii4UdM", key);
 
             // Check gzip value
-            string gzipKey = asset.GenerateCacheKey(context.Object);
+            string gzipKey = asset.GenerateCacheKey(context.Object, options);
             Assert.Equal("SvH6WGVAapgMXiPenaOGnKS_oMI", gzipKey);
         }
 

--- a/test/WebOptimizer.Core.Test/Processors/CssFinterprinterTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssFinterprinterTest.cs
@@ -67,7 +67,7 @@ namespace WebOptimizer.Test.Processors
             string result = context.Object.Content.First().Value.AsString();
 
             Assert.Equal(newUrl, result);
-            Assert.Equal("", adjuster.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", adjuster.CacheKey(new DefaultHttpContext(), context.Object));
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
@@ -22,7 +22,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("body{color:#ff0}", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Theory2]
@@ -41,7 +41,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]
@@ -56,7 +56,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("body{color:yellow;}", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]
@@ -70,7 +70,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("body{color:#ff0}", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]

--- a/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
@@ -24,7 +24,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal(output, context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]
@@ -38,7 +38,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.StartsWith("<!--", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Theory2]
@@ -57,7 +57,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]
@@ -72,7 +72,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("<!-- foo -->", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]

--- a/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
@@ -22,7 +22,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("var i=0", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Theory2]
@@ -41,7 +41,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]
@@ -56,7 +56,7 @@ namespace WebOptimizer.Test.Processors
             await minifier.ExecuteAsync(context.Object);
 
             Assert.Equal("var i=0;", context.Object.Content.First().Value.AsString());
-            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", minifier.CacheKey(new DefaultHttpContext(), context.Object));
         }
 
         [Fact2]

--- a/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/RelativePathAdjusterTest.cs
@@ -53,7 +53,7 @@ namespace WebOptimizer.Test.Processors
             await adjuster.ExecuteAsync(context.Object);
 
             Assert.Equal(newUrl, context.Object.Content.First().Value.AsString());
-            Assert.Equal("", adjuster.CacheKey(new DefaultHttpContext()));
+            Assert.Equal("", adjuster.CacheKey(new DefaultHttpContext(), context.Object));
         }
     }
 }


### PR DESCRIPTION
### PR Contents
When using assets which are generically matched, such as **/*.scss, the processor associated with this asset is used for all matching assets. This means the asset stored in the processor is the generic one.

Because the asset in the processor is the generic one, the processor is unable to know specific details about the non-generic asset. Passing these values down the chain allows the processor to access this asset-specific information in a generic context.

Other files affected by this change have been updated to reflect it.

---

### PR Reasoning
The contents of this PR are a prerequisite fix for fixing this issue: https://github.com/ligershark/WebOptimizer.Sass/issues/34

The issue there has been resolved in my fork of that project: https://github.com/alexhorner/WebOptimizer.Sass/tree/GlobalCompilerFix

This PR must be accepted before I am able to PR my fork of the other project, as a new package must be released including my fix in order to update the package reference on that project to then include in my PR.