### PR TITLE
#215 set defaults for CssBundlingSettings and CodeBundlingSettings

### DIFF
--- a/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceExtensions
     {
-        internal static CssBundlingSettings CssBundlingSettings;
+        internal static CssBundlingSettings CssBundlingSettings = new CssBundlingSettings();
 
-        internal static CodeBundlingSettings CodeBundlingSettings;
+        internal static CodeBundlingSettings CodeBundlingSettings = new CodeBundlingSettings();
 
         /// <summary>
         /// Adds WebOptimizer to the specified <see cref="IServiceCollection"/> and enables CSS and JavaScript minification.


### PR DESCRIPTION
Sets defaults on the CssBundlingSettings and CodeBundlingSettings, both of which are used by the MinifyonDemand tag helper.  Two of the 3 setup methods in ServiceExtensions do not set the values of these properties which can lead to null reference exceptions when using the MinifyOnDemand tag helper.