### PR TITLE
Use PathBase when writing individual tags

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
@@ -92,6 +92,18 @@ namespace WebOptimizer.Taghelpers
         }
 
         /// <summary>
+        /// Adds current the PathBase to a Url
+        /// </summary>
+        protected string AddPathBase(string url)
+        {
+            var pathBase = ViewContext.HttpContext.Request.PathBase;
+            if (string.IsNullOrEmpty(pathBase))
+                return url;
+
+            return pathBase + (url.StartsWith("/") ? url : ("/" + url));
+        }
+
+        /// <summary>
         /// Generates a has of the files in the bundle.
         /// </summary>
         protected string GenerateHash(IAsset asset)

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -97,7 +97,7 @@ namespace WebOptimizer.Taghelpers
 
                     fileToAdd = Path.ChangeExtension(file, "css");
                 }
-                string href = AddFileVersionToPath(fileToAdd, asset);
+                string href = AddPathBase(AddFileVersionToPath(fileToAdd, asset));
                 output.PostElement.AppendHtml($"<link href=\"{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -96,7 +96,7 @@ namespace WebOptimizer.Taghelpers
 
             foreach (string file in sourceFiles)
             {
-                string src = AddFileVersionToPath(file, asset);
+                string src = AddPathBase(AddFileVersionToPath(file, asset));
                 output.PostElement.AppendHtml($"<script src=\"{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
             }
         }


### PR DESCRIPTION
When the application has a PathBase (e.g. virtual application in IIS), the individual tags to source files (in debug mode) should be based on that root path.