### PR TITLE
FIX ASP.NET Core 6 default file provider

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -260,7 +260,10 @@ namespace WebOptimizer
         /// </summary>
         public static IFileProvider GetFileProvider(this IAsset asset, IWebHostEnvironment env)
         {
-            return asset.GetCustomFileProvider(env) ?? env.WebRootFileProvider;
+            return asset.GetCustomFileProvider(env) ??
+                   (env.WebRootFileProvider is CompositeFileProvider
+                       ? new PhysicalFileProvider(env.WebRootPath)
+                       : env.WebRootFileProvider);
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #210 

ASP.NET Core 6 changed it's default file provider to a `CompositionFileProvider` which checks if a file exists and returns a `FileNotFoundFileInfo` if it can't find the file.

This works in `net6.0` and `net5.0`