### PR TITLE
Catch exceptions in js minifier and don't re-minify single files

### DIFF
--- a/src/WebOptimizer.Core/Processors/CssMinifier.cs
+++ b/src/WebOptimizer.Core/Processors/CssMinifier.cs
@@ -21,7 +21,7 @@ namespace WebOptimizer
 
             foreach (string key in config.Content.Keys)
             {
-                if (key.EndsWith(".min"))
+                if (key.EndsWith(".min") || key.EndsWith(".min.css"))
                 {
                     content[key] = config.Content[key];
                     continue;

--- a/src/WebOptimizer.Core/Processors/HtmlMinifier.cs
+++ b/src/WebOptimizer.Core/Processors/HtmlMinifier.cs
@@ -21,7 +21,7 @@ namespace WebOptimizer
 
             foreach (string key in config.Content.Keys)
             {
-                if (key.EndsWith(".min"))
+                if (key.EndsWith(".min") || key.EndsWith(".min.html"))
                 {
                     content[key] = config.Content[key];
                     continue;

--- a/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
+++ b/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
@@ -28,12 +28,20 @@ namespace WebOptimizer
                 }
 
                 string input = config.Content[key].AsString();
-                UglifyResult result = Uglify.Js(input, Settings);
-                string minified = result.Code;
-
-                if (result.HasErrors)
+                string minified;
+                try
                 {
-                    minified = $"/* {string.Join("\r\n", result.Errors)} */\r\n" + input;
+                    UglifyResult result = Uglify.Js(input, Settings);
+                    minified = result.Code;
+                    if (result.HasErrors)
+                    {
+                        minified = $"/* {string.Join("\r\n", result.Errors)} */\r\n" + input;
+                    }
+                }
+                catch
+                {
+                    //If there's an error minifying, then use the original uminified value
+                    minified = input + "/* Exception caught attempting to minify */"; 
                 }
 
                 content[key] = minified.AsByteArray();

--- a/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
+++ b/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
@@ -21,7 +21,7 @@ namespace WebOptimizer
 
             foreach (string key in config.Content.Keys)
             {
-                if (key.EndsWith(".min"))
+                if (key.EndsWith(".min") || key.EndsWith(".min.js"))
                 {
                     content[key] = config.Content[key];
                     continue;
@@ -41,7 +41,7 @@ namespace WebOptimizer
                 catch
                 {
                     //If there's an error minifying, then use the original uminified value
-                    minified = input + "/* Exception caught attempting to minify */"; 
+                    minified = input + "/* Exception caught attempting to minify */";
                 }
 
                 content[key] = minified.AsByteArray();


### PR DESCRIPTION
1. Was running into an internal error in NUglify minifying a bundle which included signalr.js (cdnjs package "microsoft-signalr@6.0.1"). Strangely, in this package, signalr.js and signalr.min.js are both minified. Regardless, we should not just die when NUglify has internal errors. Instead, gracefully handle the exception and use the unminified version instead.
2. Looks like there is code in place to skip reminifying **bundles** that are already minified, but not **single files** when bundling is disabled, so I added a check for .min.js, .min.css, .min.html in the corresponding minifier classes (in addition to the ".min" check)