### PR TITLE
`README.md`  |  Add note about cache busting for files, `pipeline.AddFiles()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ They will get a version string added as a URL parameter:
 
 This version string changes every time one or more of the source files are modified. 
 
+**NOTE:** TagHelpers will only work on files registered as assets on the pipeline (will not work for all files in your <sctipt> and <link> tags out of the blue). make sure to add all required files as assets (glob is supported to add wildcard paths).
+
+```csharp
+services.AddWebOptimizer(pipeline =>
+{
+    pipeline.AddFiles("text/javascript", "/dist/*");
+    pipeline.AddFiles("text/css", "/css/*");
+});
+``` 
+
 This technique is called *cache busting* and is a critical component to achieving high performance, since we cannot utilize browser caching of the CSS and JavaScript files without it. That is also why it can not be disabled when using WebOptimizer.
 
 #### HTTPS Compression Considerations


### PR DESCRIPTION
Hello there, 
I recently wanted to use WebOptimizer for a project I work on, cache busting didn't work for me until I figured out (by debugging the library codes) that the file should be added somehow to the assets.

If this note (or at least giving a hint about  `pipeline.AddFiles()` function) was in the README it would save me a lot of time, hope it will do for the others.
