### PR TITLE
Fix for composite WebRootFileProvider

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -113,7 +113,7 @@ namespace WebOptimizer
                         IEnumerable<string> fileMatches = globbingResult.Files.Select(f => f.Path);
 
                         var sourceIsRooted = outSourceFile.StartsWith('/');
-                        if(sourceIsRooted)
+                        if (sourceIsRooted)
                         {
                             fileMatches = fileMatches.Select(f => "/" + f);
                         }
@@ -160,7 +160,7 @@ namespace WebOptimizer
         public string GenerateCacheKey(HttpContext context, IWebOptimizerOptions options)
         {
             var config = new AssetContext(context, this, options);
-            
+
             var cacheKey = new StringBuilder(Route);
 
             if (context.Request.Headers.TryGetValue("Accept-Encoding", out StringValues enc))
@@ -262,7 +262,7 @@ namespace WebOptimizer
         {
             return asset.GetCustomFileProvider(env) ??
                    (env.WebRootFileProvider is CompositeFileProvider
-                       ? new PhysicalFileProvider(env.WebRootPath)
+                       ? (env.WebRootFileProvider as CompositeFileProvider).FileProviders.Last()
                        : env.WebRootFileProvider);
         }
 


### PR DESCRIPTION
In the case of composite WebRootFileProvider, we use one of the child providers.
Making new PhysicalProvide on each call breaks the cache busting, the file watch events (cancelation tokens) will get lost when the temporary provider gets cleaned/deleted.

Note, the issue for me was that the version hash key of my static files was not changing when the files themselves change.

My setup is:
Linux Ubuntu 22.04
.net core 6
latest WebOptimizer from GitHub as of May 28th, 2022.
