### PR TITLE
Fix for change in .NET 6 for context.Request.Path.Value

### DIFF
--- a/src/WebOptimizer.Core/AssetPipeline.cs
+++ b/src/WebOptimizer.Core/AssetPipeline.cs
@@ -146,7 +146,7 @@ namespace WebOptimizer
         public static string NormalizeRoute(string route)
         {
             string trimmedRoute = route.Trim();
-            string cleanRoute = trimmedRoute.StartsWith( '/') || trimmedRoute.StartsWith("~")
+            string cleanRoute = trimmedRoute.StartsWith('/') || trimmedRoute.StartsWith("~")
                 ? "/" + route.Trim().TrimStart('~', '/')
                 : trimmedRoute;
 
@@ -155,6 +155,11 @@ namespace WebOptimizer
             if (index > -1)
             {
                 cleanRoute = cleanRoute.Substring(0, index);
+            }
+            
+            if(!cleanRoute.StartsWith("/"))
+            {
+                cleanRoute = "/" + cleanRoute;
             }
 
             return cleanRoute;

--- a/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetPipelineTest.cs
@@ -34,7 +34,10 @@ namespace WebOptimizer.Test
             var asset = new Asset(inputRoute, "text/css", new[] { "file.css" });
             var pipeline = new AssetPipeline();
             pipeline.AddBundle(asset);
-
+            if (!normalizedRoute.StartsWith("/"))
+            {
+                normalizedRoute = "/" + normalizedRoute;
+            }
             Assert.Equal(normalizedRoute, pipeline.Assets.First().Route);
         }
 
@@ -131,7 +134,10 @@ namespace WebOptimizer.Test
         {
             var pipeline = new AssetPipeline();
             pipeline.AddFiles("text/css", pattern);
-
+            if (!path.StartsWith("/"))
+            {
+                path = "/" + path;
+            }
             Assert.True(pipeline.TryGetAssetFromRoute(path, out var a1));
             Assert.Equal($"{path}", a1.Route);
         }

--- a/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
@@ -91,7 +91,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.AddCssBundle("foo.css", "file1.css", "file2.css");
 
-            Assert.Equal("foo.css", asset.Route);
+            Assert.Equal("/foo.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
             Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(6, asset.Processors.Count);
@@ -116,7 +116,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyCssFiles().First();
 
-            Assert.Equal("**/*.css", asset.Route);
+            Assert.Equal("/**/*.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(3 == asset.Processors.Count);

--- a/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
@@ -106,7 +106,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyHtmlFiles().First();
 
-            Assert.Equal("**/*.html", asset.Route);
+            Assert.Equal("/**/*.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(1 == asset.Processors.Count);

--- a/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
@@ -77,7 +77,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.AddJavaScriptBundle("foo.js", "file1.js", "file2.js");
 
-            Assert.Equal("foo.js", asset.Route);
+            Assert.Equal("/foo.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
             Assert.Equal(2, asset.SourceFiles.Count);
             Assert.Equal(4, asset.Processors.Count);
@@ -103,7 +103,7 @@ namespace WebOptimizer.Test.Processors
             var pipeline = new AssetPipeline();
             var asset = pipeline.MinifyJsFiles().First();
 
-            Assert.Equal("**/*.js", asset.Route);
+            Assert.Equal("/**/*.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
             Assert.True(1 == asset.SourceFiles.Count);
             Assert.True(2 == asset.Processors.Count);


### PR DESCRIPTION
In .NET 6 the value of context.Request.Path.Value appears to always have a leading "/" regardless of the reference in the html file.  An example of this is when you add a javascript bundle like:
`pipeline.AddJavaScriptBundle("Scripts/libraries.js", "Scripts/jquery.gridster.js");`
and reference it in the html file like:
`<script src="Scripts/libraries.js"></script>`
The bundle is added as an asset with the value of "Scripts/libraries.js" but the value of context.Request.Path.Value will be "/Scripts/libraries.js" resulting in no match.
This proposed change will sanitize all assets to have a leading "/" to ensure this matches.  
In my companies use of multiple javascript bundles with less compilation, this worked for us, but I'm not sure if this will mess with/break other possible routes.  This needs someone who is more familiar with the entirety of the WebOptimizer solution to ensure it doesn't introduce regressions for other people.  (I also tested it in older versions of .NET and it appeared to work without issue)  I see the failing tests, but it's because the asset being added is getting the leading "/" perhaps we need handle this by removing it at the AssetMiddleware.cs's: 
`string path = context.Request.Path.Value;`
But that doesn't seem to be the right approach either.
Hopefully @madskristensen or one of the others can take a look and evaluate the regression possibilities of this one.