### PR TITLE
Fix for always minifying JS

### DIFF
--- a/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
+++ b/src/WebOptimizer.Core/Processors/JavaScriptMinifier.cs
@@ -17,6 +17,7 @@ namespace WebOptimizer
 
         public override Task ExecuteAsync(IAssetContext config)
         {
+            if (!Settings.MinifyCode) return Task.CompletedTask;
             var content = new Dictionary<string, byte[]>();
 
             foreach (string key in config.Content.Keys)


### PR DESCRIPTION
Even when the setting MinifyCode is false the output is minified this seams to not be the correct outcome adding in this IF statement results in no changes being applied to the bundle in this processor