### PR TITLE
Feature Request for in code configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ There is a Tag Helper that understands what the `inline` attribute means and han
 WebOptimizer can also compile [Scss](http://sass-lang.com/) files into CSS. For that you need to install the `LigerShark.WebOptimizer.Sass` NuGet package and hooking it up is a breeze. Read more on the [WebOptimizer.Sass](https://github.com/ligershark/WebOptimizer.sass) website.
 
 ## Options
-You can control the options from the appsettings.json file.
+You can control the options from the appsettings.json file or in code 
 
 ```json
 {
@@ -252,6 +252,21 @@ You can control the options from the appsettings.json file.
     "allowEmptyBundle": false
   }
 }
+```
+
+```csharp
+services.AddWebOptimizer(pipeline =>
+    {
+        pipeline.AddCssBundle("/css/bundle.css", "css/*.css");
+        pipeline.AddJavaScriptBundle("/js/bundle.js", "js/plus.js", "js/minus.js");
+    },
+    option =>
+    {
+        option.EnableCaching = true;
+        option.EnableDiskCache = false;
+        option.EnableMemoryCache = true;
+        option.AllowEmptyBundle = true;
+    });
 ```
 
 **enableCaching** determines if the `cache-control` HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.

--- a/src/WebOptimizer.Core/InCodeWebOptimizerConfig.cs
+++ b/src/WebOptimizer.Core/InCodeWebOptimizerConfig.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace WebOptimizer
+{
+    internal class InCodeWebOptimizerConfig : IConfigureOptions<WebOptimizerOptions>
+    {
+        private readonly Action<WebOptimizerOptions> _configure;
+
+        public InCodeWebOptimizerConfig(Action<WebOptimizerOptions> configure)
+        {
+            _configure = configure;
+        }
+        
+        public void Configure(WebOptimizerOptions options)
+        {
+            _configure(options);
+        }
+    }
+}


### PR DESCRIPTION
**Use Case** 

All our projects use the same Web Optimizer settings. To align the configurations and make sure the configuration will not be adapted, removed or changed in the productive environments of all applications, we like to have the ability to define the settings for the Web Optimizer directly when calling the AddWebOptimizer service extension. The call to the extension is encapsulated in a global nuget for all project, pre add all general js files like file download, bootstrapping etc.  

**Code Changes PR:** 

Via the AddWebOptimizer extension you can directly configure the web optimizer options: 
```
services.AddWebOptimizer(pipeline => 
    { 
        pipeline.AddCssBundle("/css/bundle.css", "css/*.css"); 
        pipeline.AddJavaScriptBundle("/js/bundle.js", "js/plus.js", "js/minus.js"); 
    }, 
    option => 
    { 
        option.EnableCaching = true; 
        option.EnableDiskCache = false; 
        option.EnableMemoryCache = true; 
        option.AllowEmptyBundle = true; 
    }); 
```

Every extension now supports the direct configuration via code. There are no breaking changes. 

The Readme was adapted.  

Let me know if this PR has a change to get merged into main. If I there are any wishes for corrections let me know. Then we try to adapt the code as fast as possible. 