### PR TITLE
Fix LinkTagHelper crash when renderin inline styles

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -45,6 +45,11 @@ namespace WebOptimizer.Taghelpers
                 return;
             }
 
+            if (output.Attributes.ContainsName("inline"))
+            {
+                return;
+            }
+
             string href = GetValue("href", output);
             string pathBase = CurrentViewContext.HttpContext?.Request?.PathBase.Value;
 
@@ -53,7 +58,7 @@ namespace WebOptimizer.Taghelpers
                 href = href.Substring(pathBase.Length);
             }                
 
-            if (Pipeline.TryGetAssetFromRoute(href, out IAsset asset) && !output.Attributes.ContainsName("inline"))
+            if (Pipeline.TryGetAssetFromRoute(href, out IAsset asset))
             {
                 if (Options.EnableTagHelperBundling == true)
                 {


### PR DESCRIPTION
LinkTagHelper should not handle link-tag with inline-attribute and the check for the attribute is too late in the code resulting in an exception because "href"-variable becomes null:

System.NullReferenceException: Object reference not set to an instance of an object.
   at WebOptimizer.Taghelpers.LinkTagHelper.Process(TagHelperContext context, TagHelperOutput output) in ...\WebOptimizer\src\WebOptimizer.Core\Taghelpers\LinkTagHelper.cs:line 51

Checking the inline-attribute earlier fixed this.


