### PR TITLE
Fix for: Configure with code is not working because of ArgumentException

### DIFF
--- a/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
@@ -95,10 +95,9 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddWebOptimizer(this IServiceCollection services, Action<IAssetPipeline> assetPipeline, Action<WebOptimizerOptions> configureWebOptimizer)
         {
             return services.RegisterComponents(assetPipeline,
-                ServiceDescriptor.Singleton<IConfigureOptions<WebOptimizerOptions>>(_ =>
+                ServiceDescriptor.Singleton<IConfigureOptions<WebOptimizerOptions>, InCodeWebOptimizerConfig>(_ =>
                     new InCodeWebOptimizerConfig(configureWebOptimizer)));
         }
-
 
         /// <summary>
         /// Adds WebOptimizer to the specified <see cref="IServiceCollection"/>.


### PR DESCRIPTION
In the last release of ligershark/WebOptimizer, a new feature was added to configure the package directly in the source code. I tested the new release and found an issue when using the new feature.

During startup, the application crashed because of this error:

`Unhandled exception. System.ArgumentException: Implementation type cannot be 'Microsoft.Extensions.Options.IConfigureOptions`1[WebOptimizer.WebOptimizerOptions]'    for 'Microsoft.Extensions.Options.IConfigureOptions`1[WebOptimizer.WebOptimizerOptions]'. (Parameter 'descriptor')
   at Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection services, ServiceDescriptor descriptor)
   at Microsoft.Extensions.DependencyInjection.ServiceExtensions.RegisterComponents(IServiceCollection services, Action`1 assetPipeline, ServiceDescriptor configureOptions) in /home/rc/Code/devigus-github/WebOptimizer/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs:line 133
   at Microsoft.Extensions.DependencyInjection.ServiceExtensions.AddWebOptimizer(IServiceCollection services, Action`1 assetPipeline, Action`1 configureWebOptimizer) in /home/rc/Code/devigus-github/WebOptimizer/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs:line 97
   at WebOptimizerDemo.Startup.ConfigureServices(IServiceCollection services) in /home/rc/Code/devigus-github/WebOptimizer/sample/Startup.cs:line 20
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureServicesBuilder.InvokeCore(Object instance, IServiceCollection services)
   at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.UseStartup(Type startupType, HostBuilderContext context, IServiceCollection services, Object instance)
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at WebOptimizerDemo.Program.Main(String[] args)`

This pull request fixes the issue ( #269) by configuring the required generic argument.

Sorry for the inconvenience, but now the feature has been better tested and it works.