### PR TITLE
Handle implementation of IFileProvider that returns null

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -310,7 +310,7 @@ namespace WebOptimizer
             var files = new List<string>();
             var dirs = new Queue<string>();
 
-            var infos = provider.GetDirectoryContents(start);
+            var infos = provider.GetDirectoryContents(start) ?? NotFoundDirectoryContents.Singleton;
 
             foreach (var info in infos)
             {
@@ -328,7 +328,7 @@ namespace WebOptimizer
             {
                 var path = dirs.Dequeue();
 
-                infos = provider.GetDirectoryContents(path);
+                infos = provider.GetDirectoryContents(path) ?? NotFoundDirectoryContents.Singleton;
 
                 foreach (var info in infos)
                 {


### PR DESCRIPTION
We have a custom implementation of `IFileProvider` that returned `null` for any call to `GetDirectoryContents`. We don't normally deal with contents of a directory, but when WebOptimizer ran into a file it couldn't find it called `provider.GetAllFiles("/")` which eventually lead to a NRE. It took a bit for me to track down what was going on. Our IFileProvider now properly returns `NotFoundDirectoryContents.Singleton` (and is also converted to enable nullable reference types), but this change could help someone in the future from running into the same problem.