### PR TITLE
Fix to path issue when filename shares same prefix as PathBase.

### DIFF
--- a/src/WebOptimizer.Core/AssetMiddleware.cs
+++ b/src/WebOptimizer.Core/AssetMiddleware.cs
@@ -29,7 +29,7 @@ namespace WebOptimizer
             if (context.Request.PathBase.HasValue)
             {
                 string pathBase = context.Request.PathBase.Value;
-                if (path.StartsWith(pathBase))
+                if (context.Request.Path.StartsWithSegments(pathBase))
                 {
                     path = path.Substring(pathBase.Length);
                 }


### PR DESCRIPTION
Hello, 
I encountered an issue today where my client setup their virtual folder in IIS (windows server) using our application name, let's call it ABC and suddenly the site was returning 404 when we requested the bundled JS file from WebOptimizer, the odd part was that it worked as long as URI did not use all upper-case letters when referring to the virtual folder path. 

So this worked   `/abc/ABCWebBundle.js`,  but this did **not** work  `/ABC/ABCWebBundle.js`.

After some debugging I found the issue resides in line 32 in AssetMiddleware.cs.  The use of the StartsWith() method has a couple of issues.. one is that it is case sensitive whereas URIs are generally not.  Secondly, it fails in my scenario when (and probably a rare case) that the file being served shares the same prefix as the PathBase property, but does not actually reside in the same folder structure.  

In my case the path property is `/ABCWebBundle.js`, but it's mistakenly altered to `WebBundle.js` and then fails from there forward with a 404 because it starts with `/ABC` which is the PathBase.

The below PR swaps out string.StartsWith() in favor of PathString.StartsWithSegments() which will properly determine if the path exists within pathbase and covers the issue of case sensitivity.

Thank you for your time and consideration for my pull-request. 
