### PR TITLE
Bugfix for Razor Class Library assets

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -62,7 +62,7 @@ namespace WebOptimizer
             {
                 if (!config.Content.ContainsKey(file))
                 {
-                    DateTime dateChanged = await LoadFileContentAsync(this.GetFileProvider(env), config, file);
+                    DateTime dateChanged = await LoadFileContentAsync(this.GetAssetFileProvider(env), config, file);
 
                     if (dateChanged > lastModified)
                     {
@@ -174,7 +174,7 @@ namespace WebOptimizer
             var cache = (IMemoryCache)context.RequestServices.GetService(typeof(IMemoryCache));
 
             var fileVersionProvider = new FileVersionProvider(
-                this.GetFileProvider(env),
+                this.GetAssetFileProvider(env),
                 cache,
                 context.Request.PathBase);
 
@@ -262,9 +262,18 @@ namespace WebOptimizer
         public static IFileProvider GetFileProvider(this IAsset asset, IWebHostEnvironment env)
         {
             return asset.GetCustomFileProvider(env) ??
-                   (env.WebRootFileProvider is CompositeFileProvider
-                       ? (env.WebRootFileProvider as CompositeFileProvider).FileProviders.Last()
+                   (env.WebRootFileProvider is CompositeFileProvider provider
+                       ? provider.FileProviders.Last()
                        : env.WebRootFileProvider);
+        }
+        
+        /// <summary>
+        /// Gets the asset file provider. This method works for _content locations in RCL projects.
+        /// </summary>
+        public static IFileProvider GetAssetFileProvider(this IAsset asset, IWebHostEnvironment env)
+        {
+            return asset.GetCustomFileProvider(env) ??
+                   env.WebRootFileProvider as CompositeFileProvider ?? env.WebRootFileProvider;
         }
 
         /// <summary>

--- a/src/WebOptimizer.Core/CompositeFileProviderExtended.cs
+++ b/src/WebOptimizer.Core/CompositeFileProviderExtended.cs
@@ -50,10 +50,8 @@ namespace WebOptimizer
             FileProviderOptions[] fileProviders = _fileProviderOptions;
             if (fileProviders != null)
             {
-                for (var index = 0; index < fileProviders.Length; index++)
+                foreach (var item in fileProviders)
                 {
-                    var item = fileProviders[index];
-
                     if (path.StartsWith(item.RequestPath, StringComparison.OrdinalIgnoreCase))
                     {
                         outPath = path.Substring(item.RequestPath.Value.Length, path.Length - item.RequestPath.Value.Length);


### PR DESCRIPTION
```cs
        services.AddWebOptimizer(options =>
        {
            options.AddCssBundle("/css/jjmasterdata.min.css", "_content/JJMasterData.Web/css/jjmasterdata.css","_content/JJMasterData.Web/css/flatpickr/airbnb.css");
        });
```

When I reference a RCL asset like this, I get the following error:
![image](https://github.com/ligershark/WebOptimizer/assets/52143624/18f6ec0b-ee71-4be8-bfc2-c0bf20116559)
After my fix, everything works:
![image](https://github.com/ligershark/WebOptimizer/assets/52143624/7422c25d-c192-460d-99d1-19100edf5fd1)
