### PR TITLE
Improve Appveyor build logic

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,12 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 version: 3.0.{build}
-
-install:
-   # .NET Core SDK binaries
-  - ps: $urlCurrent = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/3.0.1xx/dotnet-sdk-latest-win-x64.zip"
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
-  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
-  - ps: $tempFileCurrent = [System.IO.Path]::GetTempFileName()
-  - ps: (New-Object System.Net.WebClient).DownloadFile($urlCurrent, $tempFileCurrent)
-  - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFileCurrent, $env:DOTNET_INSTALL_DIR)
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 
 build_script:
   - dotnet restore -v quiet
-  - ps: dotnet build /p:configuration=Release /p:Version=$($env:appveyor_build_version)
+  - ps: dotnet build --configuration Release --no-restore /property:ContinuousIntegrationBuild=True /p:Version=$($env:appveyor_build_version)
 
 test_script:
-  - dotnet test test/WebOptimizer.Core.Test/WebOptimizer.Core.Test.csproj
+  - dotnet test --configuration Release --no-restore --no-build test/WebOptimizer.Core.Test/WebOptimizer.Core.Test.csproj
 
 artifacts:
   - path: src\WebOptimizer.Core\bin\release\*.nupkg


### PR DESCRIPTION
* use latest build image (VS2022) to get NET 8 SDK
* release build with ContinuousIntegrationBuild = true