### PR TITLE
Added message to exception to show which asset failed

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -130,7 +130,7 @@ namespace WebOptimizer
 
                 if (files.Count == 0)
                 {
-                    throw new FileNotFoundException($"No files found matching exist in an asset");
+                    throw new FileNotFoundException($"No files found matching exist in an asset {asset}");
                 }
 
                 asset.Items[PhysicalFilesKey] = files;


### PR DESCRIPTION
In reference to https://github.com/ligershark/WebOptimizer/issues/190 , the error message is not clear about which asset it tried to load, this simply adds that to the error message