### PR TITLE
Apply cdnUrl option in ScriptTagHelper and LinkTagHelper

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/BaseTagHelper.cs
@@ -127,5 +127,16 @@ namespace WebOptimizer.Taghelpers
 
             Cache.Set(cacheKey, value, cacheOptions);
         }
+
+        /// <summary>
+        /// Adds the CdnUrl defined in Options to a Url
+        /// </summary>
+        /// <returns></returns>
+        protected string AddCdn(string url)
+        {
+            if (string.IsNullOrEmpty(Options.CdnUrl))
+                return url;
+            return Options.CdnUrl + (url.StartsWith("/") ? url : "/" + url);
+        }
     }
 }

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -62,7 +62,7 @@ namespace WebOptimizer.Taghelpers
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                    href = $"{pathBase}{GenerateHash(asset)}";
+                    href = AddCdn($"{pathBase}{GenerateHash(asset)}");
                     output.Attributes.SetAttribute("href", href);
                 }
                 else
@@ -102,7 +102,7 @@ namespace WebOptimizer.Taghelpers
 
                     fileToAdd = Path.ChangeExtension(file, "css");
                 }
-                string href = AddPathBase(AddFileVersionToPath(fileToAdd, asset));
+                string href = AddCdn(AddPathBase(AddFileVersionToPath(fileToAdd, asset)));
                 output.PostElement.AppendHtml($"<link href=\"{href}\" {string.Join(" ", attrs)} />" + Environment.NewLine);
             }
         }

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -62,13 +62,18 @@ namespace WebOptimizer.Taghelpers
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                    href = AddCdn($"{pathBase}{GenerateHash(asset)}");
+                    href = AddCdn(AddPathBase(GenerateHash(asset)));
                     output.Attributes.SetAttribute("href", href);
                 }
                 else
                 {
                     WriteIndividualTags(output, asset);
                 }
+            }
+            else
+            {
+                href = AddCdn(AddPathBase(href));
+                output.Attributes.SetAttribute("href", href);
             }
         }
 

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -62,13 +62,18 @@ namespace WebOptimizer.Taghelpers
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                    src = AddCdn($"{pathBase}{GenerateHash(asset)}");
+                    src = AddCdn(AddPathBase(GenerateHash(asset)));
                     output.Attributes.SetAttribute("src", src);
                 }
                 else
                 {
                     WriteIndividualTags(output, asset);
                 }
+            }
+            else
+            {
+                src = AddCdn(AddPathBase(src));
+                output.Attributes.SetAttribute("src", src);
             }
 
         }

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -62,7 +62,7 @@ namespace WebOptimizer.Taghelpers
             {
                 if (Options.EnableTagHelperBundling == true)
                 {
-                    src = $"{pathBase}{GenerateHash(asset)}";
+                    src = AddCdn($"{pathBase}{GenerateHash(asset)}");
                     output.Attributes.SetAttribute("src", src);
                 }
                 else
@@ -96,7 +96,7 @@ namespace WebOptimizer.Taghelpers
 
             foreach (string file in sourceFiles)
             {
-                string src = AddPathBase(AddFileVersionToPath(file, asset));
+                string src = AddCdn(AddPathBase(AddFileVersionToPath(file, asset)));
                 output.PostElement.AppendHtml($"<script src=\"{src}\" {string.Join(" ", attrs)}></script>" + Environment.NewLine);
             }
         }

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using WebOptimizer.Taghelpers;
+using Xunit;
+
+namespace WebOptimizer.Core.Test.TagHelpers
+{
+    public class LinkTagHelperTest
+    {
+        [Fact2]
+        public void AddCdn_Success()
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = true,
+                CdnUrl = "https://my-cdn.com"
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file.css"}));
+            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
+                .Returns("abc123");
+            var assetObject = asset.Object;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            
+            var linkTagHelper = new LinkTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            linkTagHelper.ViewContext = viewContext;
+            linkTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "link",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", "route") };
+            
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            var hrefAttr = tagHelperOutput.Attributes.First(x => x.Name == "href");
+            Assert.StartsWith(options.CdnUrl, hrefAttr.Value.ToString());
+        }
+        
+        [Fact2]
+        public void AddCdn_TagHelperBundlingDisabled_Success()
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            object cacheValue = "file1.css?v=abc123";
+            cache.Setup(c => c.TryGetValue("file1.css", out cacheValue)).Returns(true);
+            object cacheValue2 = "file2.css?v=def456";
+            cache.Setup(c => c.TryGetValue("file2.css", out cacheValue2)).Returns(true);
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = false,
+                CdnUrl = "https://my-cdn.com"
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file1.css", "file2.css"}));
+            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            var assetObject = asset.Object;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            
+            var linkTagHelper = new LinkTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            linkTagHelper.ViewContext = viewContext;
+            linkTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "link",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", "route") };
+            
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            string[] linkTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+            Assert.All(linkTags, s => Assert.StartsWith($"<link href=\"{options.CdnUrl}", s));
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
@@ -1,17 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -23,8 +18,12 @@ namespace WebOptimizer.Core.Test.TagHelpers
 {
     public class LinkTagHelperTest
     {
-        [Fact2]
-        public void AddCdn_Success()
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsAsset_Success(string cdnUrl, string pathBase)
         {
             var fileInfo = new Mock<IFileInfo>();
             fileInfo.SetupGet(fi => fi.Exists).Returns(true);
@@ -35,19 +34,20 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var cache = new Mock<IMemoryCache>();
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
+            
             context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
                 .Returns(false)
                 .Returns(true);
             context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
                 .Returns(env.Object);
-
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
             
             var options = new WebOptimizerOptions
             {
                 EnableTagHelperBundling = true,
-                CdnUrl = "https://my-cdn.com"
+                CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
             optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
@@ -57,18 +57,21 @@ namespace WebOptimizer.Core.Test.TagHelpers
             
             var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
             optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/testbundle";
+            var cacheKey = "abc123";
             
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/css");
-            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.Route).Returns(route);
             asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file.css"}));
             asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
-                .Returns("abc123");
+                .Returns(cacheKey);
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
-            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
             
             var linkTagHelper = new LinkTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
             var viewContext = new ViewContext
@@ -83,17 +86,21 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 new TagHelperAttributeList(),
                 new Dictionary<object, object>(),
                 "unique");
-            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", "route") };
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
             
             var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var hrefAttr = tagHelperOutput.Attributes.First(x => x.Name == "href");
-            Assert.StartsWith(options.CdnUrl, hrefAttr.Value.ToString());
+            Assert.Equal($"{options.CdnUrl}{pathBase}{route}?v={cacheKey}", hrefAttr.Value.ToString());
         }
-        
-        [Fact2]
-        public void AddCdn_TagHelperBundlingDisabled_Success()
+
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsNotAsset_Success(string cdnUrl, string pathBase)
         {
             var fileInfo = new Mock<IFileInfo>();
             fileInfo.SetupGet(fi => fi.Exists).Returns(true);
@@ -102,25 +109,22 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var env = new Mock<IWebHostEnvironment>();
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
             var cache = new Mock<IMemoryCache>();
-            object cacheValue = "file1.css?v=abc123";
-            cache.Setup(c => c.TryGetValue("file1.css", out cacheValue)).Returns(true);
-            object cacheValue2 = "file2.css?v=def456";
-            cache.Setup(c => c.TryGetValue("file2.css", out cacheValue2)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
+            
             context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
                 .Returns(false)
                 .Returns(true);
             context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
                 .Returns(env.Object);
-
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
             
             var options = new WebOptimizerOptions
             {
-                EnableTagHelperBundling = false,
-                CdnUrl = "https://my-cdn.com"
+                EnableTagHelperBundling = true,
+                CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
             optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
@@ -130,16 +134,10 @@ namespace WebOptimizer.Core.Test.TagHelpers
             
             var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
             optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
-            
-            var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.SetupGet(a => a.ContentType).Returns("text/css");
-            asset.SetupGet(a => a.Route).Returns("route");
-            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file1.css", "file2.css"}));
-            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
-            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
-            var assetObject = asset.Object;
+
+            IAsset asset;
             var assetPipeline = new Mock<IAssetPipeline>();
-            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
             
             var linkTagHelper = new LinkTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
             var viewContext = new ViewContext
@@ -154,13 +152,93 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 new TagHelperAttributeList(),
                 new Dictionary<object, object>(),
                 "unique");
-            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", "route") };
+            var hrefValue = $"{pathBase}/lib/bootstrap/dist/css/bootstrap.min.css";
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", hrefValue) };
+            
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            var hrefAttr = tagHelperOutput.Attributes.First(x => x.Name == "href");
+            Assert.Equal($"{options.CdnUrl}{hrefValue}", hrefAttr.Value.ToString());
+        }
+        
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsAsset_TagHelperBundlingDisabled_Success(string cdnUrl, string pathBase)
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            object cacheValue = "/file1.css?v=abc123";
+            cache.Setup(c => c.TryGetValue("file1.css", out cacheValue)).Returns(true);
+            object cacheValue2 = "/file2.css?v=def456";
+            cache.Setup(c => c.TryGetValue("file2.css", out cacheValue2)).Returns(true);
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = false,
+                CdnUrl = cdnUrl
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/testbundle";
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/css");
+            asset.SetupGet(a => a.Route).Returns(route);
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file1.css", "file2.css"}));
+            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            var assetObject = asset.Object;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
+            
+            var linkTagHelper = new LinkTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            linkTagHelper.ViewContext = viewContext;
+            linkTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "link",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
             
             var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] linkTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
-            Assert.All(linkTags, s => Assert.StartsWith($"<link href=\"{options.CdnUrl}", s));
+            Assert.Equal(2, linkTags.Length);
+            Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue}\"", linkTags[0]);
+            Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", linkTags[1]);            
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using WebOptimizer.Taghelpers;
+using Xunit;
+
+namespace WebOptimizer.Core.Test.TagHelpers
+{
+    public class ScriptTagHelperTest
+    {
+        [Fact2]
+        public void AddCdn_Success()
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = true,
+                CdnUrl = "https://my-cdn.com"
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/javascript");
+            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file.js"}));
+            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
+                .Returns("abc123");
+            var assetObject = asset.Object;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            
+            var scriptTagHelper =
+                new ScriptTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            scriptTagHelper.ViewContext = viewContext;
+            scriptTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "script",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", "route") };
+            
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            
+            scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            var srcAttr = tagHelperOutput.Attributes.First(x => x.Name == "src");
+            Assert.StartsWith(options.CdnUrl, srcAttr.Value.ToString());
+        }
+        
+        [Fact2]
+        public void AddCdn_TagHelperBundlingDisabled_Success()
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            object cacheValue = "file1.js?v=abc123";
+            cache.Setup(c => c.TryGetValue("file1.js", out cacheValue)).Returns(true);
+            object cacheValue2 = "file2.js?v=def456";
+            cache.Setup(c => c.TryGetValue("file2.js", out cacheValue2)).Returns(true);
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = false,
+                CdnUrl = "https://my-cdn.com"
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            
+            var asset = new Mock<IAsset>().SetupAllProperties();
+            asset.SetupGet(a => a.ContentType).Returns("text/javascript");
+            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file1.js", "file2.js"}));
+            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            var assetObject = asset.Object;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            
+            var scriptTagHelper = new ScriptTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            scriptTagHelper.ViewContext = viewContext;
+            scriptTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "script",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", "route") };
+            
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            string[] scriptTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+            Assert.All(scriptTags, s => Assert.StartsWith($"<script src=\"{options.CdnUrl}", s));
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
@@ -18,8 +18,12 @@ namespace WebOptimizer.Core.Test.TagHelpers
 {
     public class ScriptTagHelperTest
     {
-        [Fact2]
-        public void AddCdn_Success()
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsAsset_Success(string cdnUrl, string pathBase)
         {
             var fileInfo = new Mock<IFileInfo>();
             fileInfo.SetupGet(fi => fi.Exists).Returns(true);
@@ -30,19 +34,20 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var cache = new Mock<IMemoryCache>();
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
+            
             context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
                 .Returns(false)
                 .Returns(true);
             context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
                 .Returns(env.Object);
-
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
             
             var options = new WebOptimizerOptions
             {
                 EnableTagHelperBundling = true,
-                CdnUrl = "https://my-cdn.com"
+                CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
             optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
@@ -52,18 +57,21 @@ namespace WebOptimizer.Core.Test.TagHelpers
             
             var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
             optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/testbundle";
+            var cacheKey = "abc123";
             
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/javascript");
-            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.Route).Returns(route);
             asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file.js"}));
             asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
-                .Returns("abc123");
+                .Returns(cacheKey);
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
-            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
             
             var scriptTagHelper =
                 new ScriptTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
@@ -79,18 +87,22 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 new TagHelperAttributeList(),
                 new Dictionary<object, object>(),
                 "unique");
-            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", "route") };
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
             
             var tagHelperOutput = new TagHelperOutput("script", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var srcAttr = tagHelperOutput.Attributes.First(x => x.Name == "src");
-            Assert.StartsWith(options.CdnUrl, srcAttr.Value.ToString());
+            Assert.Equal($"{options.CdnUrl}{pathBase}{route}?v={cacheKey}", srcAttr.Value.ToString());
         }
         
-        [Fact2]
-        public void AddCdn_TagHelperBundlingDisabled_Success()
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsNotAsset_Success(string cdnUrl, string pathBase)
         {
             var fileInfo = new Mock<IFileInfo>();
             fileInfo.SetupGet(fi => fi.Exists).Returns(true);
@@ -99,25 +111,22 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var env = new Mock<IWebHostEnvironment>();
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
             var cache = new Mock<IMemoryCache>();
-            object cacheValue = "file1.js?v=abc123";
-            cache.Setup(c => c.TryGetValue("file1.js", out cacheValue)).Returns(true);
-            object cacheValue2 = "file2.js?v=def456";
-            cache.Setup(c => c.TryGetValue("file2.js", out cacheValue2)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
+            
             context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
                 .Returns(false)
                 .Returns(true);
             context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
                 .Returns(env.Object);
-
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
             
             var options = new WebOptimizerOptions
             {
-                EnableTagHelperBundling = false,
-                CdnUrl = "https://my-cdn.com"
+                EnableTagHelperBundling = true,
+                CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
             optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
@@ -127,16 +136,89 @@ namespace WebOptimizer.Core.Test.TagHelpers
             
             var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
             optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            IAsset asset;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
             
+            var scriptTagHelper =
+                new ScriptTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = context.Object
+            };
+            scriptTagHelper.ViewContext = viewContext;
+            scriptTagHelper.CurrentViewContext = viewContext;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "script",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var srcValue = $"{pathBase}/lib/bootstrap/dist/js/bootstrap.min.js";
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", srcValue) };
+            
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            
+            scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
+            var srcAttr = tagHelperOutput.Attributes.First(x => x.Name == "src");
+            Assert.Equal($"{options.CdnUrl}{srcValue}", srcAttr.Value.ToString());
+        }
+        
+        [Theory2]
+        [InlineData("https://my-cdn.com", "")]
+        [InlineData("https://my-cdn.com", "/myapp")]
+        [InlineData("", "")]
+        [InlineData("", "/myapp")]
+        public void CdnUrl_RouteIsAsset_TagHelperBundlingDisabled_Success(string cdnUrl, string pathBase)
+        {
+            var fileInfo = new Mock<IFileInfo>();
+            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
+            var fileProvider = new Mock<IFileProvider>();
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            var cache = new Mock<IMemoryCache>();
+            object cacheValue = "/file1.js?v=abc123";
+            cache.Setup(c => c.TryGetValue("file1.js", out cacheValue)).Returns(true);
+            object cacheValue2 = "/file2.js?v=def456";
+            cache.Setup(c => c.TryGetValue("file2.js", out cacheValue2)).Returns(true);
+            var context = new Mock<HttpContext>().SetupAllProperties();
+            StringValues ae = "gzip, deflate";
+            
+            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
+                .Returns(false)
+                .Returns(true);
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache.Object);
+            context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
+            
+            var options = new WebOptimizerOptions
+            {
+                EnableTagHelperBundling = false,
+                CdnUrl = cdnUrl
+            };
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+            
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+            
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/testbundle";
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/javascript");
-            asset.SetupGet(a => a.Route).Returns("route");
+            asset.SetupGet(a => a.Route).Returns(route);
             asset.SetupGet(a => a.SourceFiles).Returns(new HashSet<string>(new []{"file1.js", "file2.js"}));
             asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
-            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out assetObject)).Returns(true);
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
             
             var scriptTagHelper = new ScriptTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object);
             var viewContext = new ViewContext
@@ -151,13 +233,15 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 new TagHelperAttributeList(),
                 new Dictionary<object, object>(),
                 "unique");
-            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", "route") };
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
             
             var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] scriptTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
-            Assert.All(scriptTags, s => Assert.StartsWith($"<script src=\"{options.CdnUrl}", s));
+            Assert.Equal(2, scriptTags.Length);
+            Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue}\"", scriptTags[0]);
+            Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", scriptTags[1]);
         }
     }
 }


### PR DESCRIPTION
The cdnUrl option is not currently being applied via the ScriptTagHelper and LinkTagHelper. This PR looks to rectify that.

Resolves issue [#224](https://github.com/ligershark/WebOptimizer/issues/224)