### PR TITLE
Restore NET 6 support and remove System.Text.Json dependency

### DIFF
--- a/src/WebOptimizer.Core/WebOptimizer.Core.csproj
+++ b/src/WebOptimizer.Core/WebOptimizer.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebOptimizer.Core.xml</DocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -21,11 +21,11 @@
     <RootNamespace>WebOptimizer</RootNamespace>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="NUglify" Version="1.21.9" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Build/$(PackageId).targets">


### PR DESCRIPTION
#315 basically removed NET 6 support (removed netcoreapp3.1) and NET 6 is still supported. This PR re-introduces the support and also removes System.Text.Json reference as it comes in the box for NET 6 and later.