### PR TITLE
Taghelpers bug fix: do not add cdn or path base if url is absolute

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -72,7 +72,10 @@ namespace WebOptimizer.Taghelpers
             }
             else
             {
-                href = AddCdn(AddPathBase(href));
+                if (!Uri.TryCreate(href, UriKind.Absolute, out Uri _))
+                {
+                    href = AddCdn(AddPathBase(href));
+                }
                 output.Attributes.SetAttribute("href", href);
             }
         }

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -72,7 +72,10 @@ namespace WebOptimizer.Taghelpers
             }
             else
             {
-                src = AddCdn(AddPathBase(src));
+                if (!Uri.TryCreate(src, UriKind.Absolute, out Uri _))
+                {
+                    src = AddCdn(AddPathBase(src));
+                }
                 output.Attributes.SetAttribute("src", src);
             }
 


### PR DESCRIPTION
Fixes a bug I recently introduced where the tag helpers add the CDN and pathBase to absolute url's. These should not be added to absolute URLs.

Fixes issue [314](https://github.com/ligershark/WebOptimizer/issues/314)