### PR TITLE
Optimize for large bundles with numerous globs

### DIFF
--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,11 @@ namespace WebOptimizer
 {
     internal class Asset : IAsset
     {
+        /// <summary>
+        /// Private const extracted from <see cref="GlobbingUrlBuilder"/>.
+        /// Used to join multiple patterns for that class.
+        /// </summary>
+        internal const string PatternSeparator = ",";
         private readonly ILogger<Asset> _logger;
         internal const string PhysicalFilesKey = "PhysicalFiles";
         private readonly object _sync = new();
@@ -50,9 +56,10 @@ namespace WebOptimizer
         public async Task<byte[]> ExecuteAsync(HttpContext context, IWebOptimizerOptions options)
         {
             var env = (IWebHostEnvironment)context.RequestServices.GetService(typeof(IWebHostEnvironment));
+            var cache = (IMemoryCache)context.RequestServices.GetService(typeof(IMemoryCache));
             var config = new AssetContext(context, this, options);
 
-            IEnumerable<string> files = ExpandGlobs(this, env);
+            IEnumerable<string> files = ExpandGlobs(this, env, cache);
 
             DateTime lastModified = DateTime.MinValue;
 
@@ -84,12 +91,17 @@ namespace WebOptimizer
             return config.Content.FirstOrDefault().Value;
         }
 
-        public static IEnumerable<string> ExpandGlobs(IAsset asset, IWebHostEnvironment env)
+        public static IEnumerable<string> ExpandGlobs(IAsset asset, IWebHostEnvironment env, IMemoryCache cache)
         {
             var files = new List<string>();
 
             if (asset.SourceFiles.Any())
             {
+                var excludePattern =
+                    asset.ExcludeFiles.Count == 0
+                        ? null
+                        : string.Join(PatternSeparator, asset.ExcludeFiles);
+
                 foreach (string sourceFile in asset.SourceFiles)
                 {
                     var provider = asset.GetFileProvider(env, sourceFile, out string outSourceFile);
@@ -103,19 +115,13 @@ namespace WebOptimizer
                     }
                     else
                     {
-                        var virtualFilePaths = provider.GetAllFiles("/");
-
-                        var matcher = new Matcher();
-                        matcher.AddInclude(outSourceFile);
-                        matcher.AddExcludePatterns(asset.ExcludeFiles);
-                        PatternMatchingResult globbingResult = matcher.Match(virtualFilePaths);
-
-                        IEnumerable<string> fileMatches = globbingResult.Files.Select(f => f.Path);
+                        var globbingUrlBuilder = new GlobbingUrlBuilder(provider, cache, requestPathBase: /*context.Request.PathBase*/ null);
+                        IEnumerable<string> fileMatches = globbingUrlBuilder.BuildUrlList(staticUrl: null, includePattern: outSourceFile, excludePattern: excludePattern);
 
                         var sourceIsRooted = outSourceFile.StartsWith('/');
-                        if (sourceIsRooted)
+                        if (!sourceIsRooted)
                         {
-                            fileMatches = fileMatches.Select(f => "/" + f);
+                            fileMatches = fileMatches.Select(f => f.TrimStart('/'));
                         }
 
                         if (!fileMatches.Any())
@@ -179,7 +185,7 @@ namespace WebOptimizer
 
             if (!Items.ContainsKey(PhysicalFilesKey))
             {
-                physicalFiles = ExpandGlobs(this, env);
+                physicalFiles = ExpandGlobs(this, env, cache);
             }
             else
             {

--- a/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkTagHelper.cs
@@ -105,7 +105,7 @@ namespace WebOptimizer.Taghelpers
                 attrs.Add(attr);
             }
 
-            IEnumerable<string> sourceFiles = Asset.ExpandGlobs(asset, HostingEnvironment);
+            IEnumerable<string> sourceFiles = Asset.ExpandGlobs(asset, HostingEnvironment, Cache);
 
             foreach (string file in sourceFiles)
             {

--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -102,7 +102,7 @@ namespace WebOptimizer.Taghelpers
                 attrs.Add(attr);
             }
 
-            IEnumerable<string> sourceFiles = Asset.ExpandGlobs(asset, HostingEnvironment);
+            IEnumerable<string> sourceFiles = Asset.ExpandGlobs(asset, HostingEnvironment, Cache);
 
             foreach (string file in sourceFiles)
             {

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -1,12 +1,16 @@
-﻿using System.IO;
-using System.Linq;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using WebOptimizer.Core.Test.Mocks;
 using Xunit;
 
 namespace WebOptimizer.Test
@@ -93,6 +97,114 @@ namespace WebOptimizer.Test
             var asset = new Asset("/route", "content/type", [], logger.Object);
 
             Assert.Equal(asset.Route, asset.ToString());
+        }
+
+        /// <summary>
+        /// Tests that asset's <see cref="Asset.ExecuteAsync"/> correctly reads all files,
+        /// including those in nested directories, when using a glob pattern.
+        ///
+        /// Also, tests <see cref="GlobbingUrlBuilder"/> from <see cref="Asset.ExpandGlobs"/> and checks
+        /// if it works nicely with nested directories.
+        /// </summary>
+        [Fact2]
+        public async Task ExecuteAsync_GlobMatchesNestedDirectories_ReadsAllFiles()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root =
+                MockFileInfo.CreateDirectory("", date,
+                [
+                    new MockFileInfo("file1.css", date, Encoding.UTF8.GetBytes("body { background-color: red; }")),
+                    new MockFileInfo("file2.css", date, Encoding.UTF8.GetBytes("body { background-color: blue; }")),
+                    MockFileInfo.CreateDirectory("sub", date,
+                    [
+                        new MockFileInfo("file3.css", date, Encoding.UTF8.GetBytes("body { background-color: green; }")),
+                    ]),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["**/*.css"], logger.Object);
+            asset.Concatenate();
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            var context = new Mock<HttpContext>();
+            context.SetupAllProperties();
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache);
+            context.Setup(c => c.Response.Headers)
+                .Returns(new HeaderDictionary());
+
+            var options = new WebOptimizerOptions();
+
+            byte[] result = await asset.ExecuteAsync(context.Object, options);
+            string content = Encoding.UTF8.GetString(result);
+
+            Assert.Contains("background-color: red", content);
+            Assert.Contains("background-color: blue", content);
+            Assert.Contains("background-color: green", content);
+        }
+
+        /// <summary>
+        /// Same scenario as <see cref="ExecuteAsync_GlobMatchesNestedDirectories_ReadsAllFiles"/> but
+        /// backed by a real <see cref="PhysicalFileProvider"/> over a temporary directory tree
+        /// instead of a mocked file provider.
+        /// </summary>
+        [Fact2]
+        public async Task ExecuteAsync_GlobMatchesNestedDirectories_PhysicalFileProvider_ReadsAllFiles()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "WebOptimizerTest_" + Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "sub"));
+                File.WriteAllText(Path.Combine(root, "file1.css"), "body { background-color: red; }");
+                File.WriteAllText(Path.Combine(root, "file2.css"), "body { background-color: blue; }");
+                File.WriteAllText(Path.Combine(root, "sub", "file3.css"), "body { background-color: green; }");
+
+                var fileProvider = new PhysicalFileProvider(root);
+
+                var logger = new Mock<ILogger<Asset>>();
+                var asset = new Asset("/all.css", "text/css", ["**/*.css"], logger.Object);
+                asset.Concatenate();
+
+                var env = new Mock<IWebHostEnvironment>();
+                env.Setup(e => e.WebRootFileProvider)
+                    .Returns(fileProvider);
+
+                var cache = new MemoryCache(new MemoryCacheOptions());
+
+                var context = new Mock<HttpContext>();
+                context.SetupAllProperties();
+                context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                    .Returns(env.Object);
+                context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                    .Returns(cache);
+                context.Setup(c => c.Response.Headers)
+                    .Returns(new HeaderDictionary());
+
+                var options = new WebOptimizerOptions();
+
+                byte[] result = await asset.ExecuteAsync(context.Object, options);
+                string content = Encoding.UTF8.GetString(result);
+
+                Assert.Contains("background-color: red", content);
+                Assert.Contains("background-color: blue", content);
+                Assert.Contains("background-color: green", content);
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -150,6 +150,8 @@ namespace WebOptimizer.Test
             Assert.Contains("background-color: red", content);
             Assert.Contains("background-color: blue", content);
             Assert.Contains("background-color: green", content);
+
+            Mock.VerifyAll(env, context);
         }
 
         /// <summary>
@@ -198,6 +200,8 @@ namespace WebOptimizer.Test
                 Assert.Contains("background-color: red", content);
                 Assert.Contains("background-color: blue", content);
                 Assert.Contains("background-color: green", content);
+
+                Mock.VerifyAll(context, env);
             }
             finally
             {
@@ -247,6 +251,8 @@ namespace WebOptimizer.Test
             int indexA = content.IndexOf(".a {", StringComparison.Ordinal);
             Assert.True(indexB >= 0 && indexA >= 0, "both files must be bundled");
             Assert.True(indexB < indexA, "b.css must come before a.css, matching SourceFiles order");
+
+            Mock.VerifyAll(env, context);
         }
 
         [Fact2]
@@ -291,6 +297,8 @@ namespace WebOptimizer.Test
             int indexRoot = content.IndexOf(".root {", StringComparison.Ordinal);
             Assert.True(indexNested >= 0 && indexRoot >= 0, "both files must be bundled");
             Assert.True(indexNested < indexRoot, "sub/*.css pattern is listed first, so its file must come first");
+
+            Mock.VerifyAll(env, context);
         }
 
         [Fact2]
@@ -316,6 +324,8 @@ namespace WebOptimizer.Test
             IEnumerable<string> files = Asset.ExpandGlobs(asset, env.Object, cache);
 
             Assert.Equal(new[] { "b.css", "a.css" }, files);
+
+            Mock.VerifyAll(env);
         }
 
         [Fact2]
@@ -344,6 +354,8 @@ namespace WebOptimizer.Test
             IEnumerable<string> files = Asset.ExpandGlobs(asset, env.Object, cache);
 
             Assert.Equal(new[] { "sub/nested.css", "root.css" }, files);
+
+            Mock.VerifyAll(env);
         }
 
         /// <summary>
@@ -393,6 +405,8 @@ namespace WebOptimizer.Test
                 "sub/*.css group precedes style-*.css group");
             Assert.True(indexStyleA < indexAlpha && indexStyleB < indexAlpha,
                 "style-*.css group precedes alpha.css group");
+
+            Mock.VerifyAll(env);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -205,6 +206,193 @@ namespace WebOptimizer.Test
                     Directory.Delete(root, recursive: true);
                 }
             }
+        }
+
+        [Fact2]
+        public async Task ExecuteAsync_ExplicitSourceFiles_PreservesSourceFilesOrder()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root = MockFileInfo.CreateDirectory("", date,
+            [
+                new MockFileInfo("a.css", date, Encoding.UTF8.GetBytes(".a { color: red; }")),
+                new MockFileInfo("b.css", date, Encoding.UTF8.GetBytes(".b { color: blue; }")),
+            ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["b.css", "a.css"], logger.Object);
+            asset.Concatenate();
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            var context = new Mock<HttpContext>();
+            context.SetupAllProperties();
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache);
+            context.Setup(c => c.Response.Headers)
+                .Returns(new HeaderDictionary());
+
+            var options = new WebOptimizerOptions();
+
+            byte[] result = await asset.ExecuteAsync(context.Object, options);
+            string content = Encoding.UTF8.GetString(result);
+
+            int indexB = content.IndexOf(".b {", StringComparison.Ordinal);
+            int indexA = content.IndexOf(".a {", StringComparison.Ordinal);
+            Assert.True(indexB >= 0 && indexA >= 0, "both files must be bundled");
+            Assert.True(indexB < indexA, "b.css must come before a.css, matching SourceFiles order");
+        }
+
+        [Fact2]
+        public async Task ExecuteAsync_MultipleGlobPatterns_PreservesPatternOrder()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root = MockFileInfo.CreateDirectory("", date,
+            [
+                new MockFileInfo("root.css", date, Encoding.UTF8.GetBytes(".root { color: red; }")),
+                MockFileInfo.CreateDirectory("sub", date,
+                [
+                    new MockFileInfo("nested.css", date, Encoding.UTF8.GetBytes(".nested { color: blue; }")),
+                ]),
+            ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["sub/*.css", "*.css"], logger.Object);
+            asset.Concatenate();
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            var context = new Mock<HttpContext>();
+            context.SetupAllProperties();
+            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
+                .Returns(env.Object);
+            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
+                .Returns(cache);
+            context.Setup(c => c.Response.Headers)
+                .Returns(new HeaderDictionary());
+
+            var options = new WebOptimizerOptions();
+
+            byte[] result = await asset.ExecuteAsync(context.Object, options);
+            string content = Encoding.UTF8.GetString(result);
+
+            int indexNested = content.IndexOf(".nested {", StringComparison.Ordinal);
+            int indexRoot = content.IndexOf(".root {", StringComparison.Ordinal);
+            Assert.True(indexNested >= 0 && indexRoot >= 0, "both files must be bundled");
+            Assert.True(indexNested < indexRoot, "sub/*.css pattern is listed first, so its file must come first");
+        }
+
+        [Fact2]
+        public void ExpandGlobs_ExplicitSourceFiles_PreservesSourceFilesOrder()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root = MockFileInfo.CreateDirectory("", date,
+            [
+                new MockFileInfo("a.css", date, Encoding.UTF8.GetBytes(".a { color: red; }")),
+                new MockFileInfo("b.css", date, Encoding.UTF8.GetBytes(".b { color: blue; }")),
+            ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["b.css", "a.css"], logger.Object);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            IEnumerable<string> files = Asset.ExpandGlobs(asset, env.Object, cache);
+
+            Assert.Equal(new[] { "b.css", "a.css" }, files);
+        }
+
+        [Fact2]
+        public void ExpandGlobs_MultipleGlobPatterns_PreservesPatternOrder()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root = MockFileInfo.CreateDirectory("", date,
+            [
+                new MockFileInfo("root.css", date, Encoding.UTF8.GetBytes(".root { color: red; }")),
+                MockFileInfo.CreateDirectory("sub", date,
+                [
+                    new MockFileInfo("nested.css", date, Encoding.UTF8.GetBytes(".nested { color: blue; }")),
+                ]),
+            ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["sub/*.css", "*.css"], logger.Object);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            IEnumerable<string> files = Asset.ExpandGlobs(asset, env.Object, cache);
+
+            Assert.Equal(new[] { "sub/nested.css", "root.css" }, files);
+        }
+
+        /// <summary>
+        /// <see cref="Asset.ExpandGlobs"/> maps every <see cref="IAsset.SourceFiles"/> entry to a group of
+        /// matched files and keeps those groups in entry order. The order *within* a glob group is an
+        /// implementation detail and is not asserted.
+        /// </summary>
+        [Fact2]
+        public void ExpandGlobs_MixedExplicitAndGlobPatterns_KeepsEntryGroupOrder()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root = MockFileInfo.CreateDirectory("", date,
+            [
+                new MockFileInfo("alpha.css", date, Encoding.UTF8.GetBytes(".alpha { color: red; }")),
+                new MockFileInfo("zeta.css", date, Encoding.UTF8.GetBytes(".zeta { color: blue; }")),
+                new MockFileInfo("style-a.css", date, Encoding.UTF8.GetBytes(".style-a { color: #FF0000; }")),
+                new MockFileInfo("style-b.css", date, Encoding.UTF8.GetBytes(".style-b { color: #00FF00; }")),
+                MockFileInfo.CreateDirectory("sub", date,
+                [
+                    new MockFileInfo("inner.css", date, Encoding.UTF8.GetBytes(".inner { color: green; }")),
+                ]),
+            ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var logger = new Mock<ILogger<Asset>>();
+            var asset = new Asset("/all.css", "text/css", ["zeta.css", "sub/*.css", "style-*.css", "alpha.css"], logger.Object);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider)
+                .Returns(fileProvider);
+
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            List<string> files = [.. Asset.ExpandGlobs(asset, env.Object, cache)];
+            // zeta.css, sub/inner.css, (style-a.css, style-b.css - any order), alpha.css
+
+            Assert.Equal(5, files.Count);
+
+            int indexZeta = files.IndexOf("zeta.css");
+            int indexInner = files.IndexOf("sub/inner.css");
+            int indexStyleA = files.IndexOf("style-a.css");
+            int indexStyleB = files.IndexOf("style-b.css");
+            int indexAlpha = files.IndexOf("alpha.css");
+
+            Assert.True(indexZeta < indexInner, "zeta.css group precedes sub/*.css group");
+            Assert.True(indexInner < indexStyleA && indexInner < indexStyleB,
+                "sub/*.css group precedes style-*.css group");
+            Assert.True(indexStyleA < indexAlpha && indexStyleB < indexAlpha,
+                "style-*.css group precedes alpha.css group");
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/Mocks/MockChangeToken.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockChangeToken.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Extensions.Primitives;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    public class MockChangeToken : IChangeToken
+    {
+        public bool ActiveChangeCallbacks => false;
+
+        public bool HasChanged => false;
+
+        public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+        {
+            return NoopDisposable.Instance;
+        }
+
+        private class NoopDisposable : IDisposable
+        {
+            public static readonly NoopDisposable Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockDirectoryContents.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockDirectoryContents.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.FileProviders;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    public class MockDirectoryContents : IDirectoryContents
+    {
+        private readonly IEnumerable<IFileInfo> _files;
+
+        public MockDirectoryContents(IEnumerable<IFileInfo> files)
+        {
+            _files = files;
+        }
+
+        public bool Exists => true;
+
+        public IEnumerator<IFileInfo> GetEnumerator()
+        {
+            return _files.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _files.GetEnumerator();
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileInfo.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileInfo.cs
@@ -12,11 +12,28 @@ namespace WebOptimizer.Core.Test.Mocks
     {
         private readonly byte[] _data;
 
-        public MockFileInfo(string name, DateTimeOffset lastModified, byte[] data)
+        public MockFileInfo(string fileName, DateTimeOffset lastModified, byte[] data)
         {
             _data = data;
-            Name = name;
+            Name = fileName;
             LastModified = lastModified;
+        }
+
+        private MockFileInfo(string directoryName, DateTimeOffset lastModified, IList<MockFileInfo> files = null)
+        {
+            _data = null;
+            Name = directoryName;
+            LastModified = lastModified;
+            IsDirectory = true;
+            Files = files;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MockFileInfo"/> representing a directory.
+        /// </summary>
+        public static MockFileInfo CreateDirectory(string directoryName, DateTimeOffset lastModified, IList<MockFileInfo> files)
+        {
+            return new MockFileInfo(directoryName, lastModified, files);
         }
 
         public Stream CreateReadStream()
@@ -25,11 +42,12 @@ namespace WebOptimizer.Core.Test.Mocks
         }
 
         public bool Exists => true;
-        public bool IsDirectory => false;
+        public bool IsDirectory { get; }
         public DateTimeOffset LastModified { get; }
         public long Length => _data.Length;
         public string Name { get; }
         public string PhysicalPath => null;
+        public IList<MockFileInfo> Files {  get; }
     }
 
 }

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    // grabbed the logic from https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
+    // and made it recursive
+    internal static class MockFileProvider
+    {
+        public static IFileProvider Create(MockFileInfo rootNode)
+        {
+            if (rootNode.Files == null || !rootNode.Files.Any())
+            {
+                throw new ArgumentException($"{nameof(rootNode)} must have children.", nameof(rootNode));
+            }
+
+            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>()))
+                .Returns((string p) => new NotFoundFileInfo(p));
+            SetupDirectoriesFiles(fileProvider, rootNode);
+            fileProvider.Setup(fp => fp.Watch(It.IsAny<string>()))
+                .Returns(new Mock<IChangeToken>().Object);
+
+            return fileProvider.Object;
+        }
+
+        private static void SetupDirectoriesFiles(Mock<IFileProvider> fileProviderMock, MockFileInfo directory)
+        {
+            var stack = new Stack<(MockFileInfo fileInfo, string directoryPath)>();
+            stack.Push((directory, string.Empty));
+
+            while (stack.Count > 0)
+            {
+                var (fileInfo, directoryPath) = stack.Pop();
+
+                if (fileInfo.IsDirectory)
+                {
+                    var children = fileInfo.Files;
+
+                    var directoryContents = new Mock<IDirectoryContents>();
+                    directoryContents.Setup(dc => dc.Exists).Returns(true);
+                    directoryContents.Setup(dc => dc.GetEnumerator())
+                        .Returns(() => children.GetEnumerator());
+                    directoryContents
+                        .As<IEnumerable>()
+                        .Setup(dc => dc.GetEnumerator())
+                        .Returns(() => children.GetEnumerator());
+
+                    var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
+
+                    fileProviderMock.Setup(fp => fp.GetDirectoryContents(fullPath))
+                        .Returns(directoryContents.Object);
+
+                    foreach (var child in children)
+                    {
+                        stack.Push((child, fullPath));
+                    }
+                }
+                else
+                {
+                    var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
+                    fileProviderMock.Setup(fp => fp.GetFileInfo(fullPath))
+                        .Returns(fileInfo);
+                    fileProviderMock.Setup(fp => fp.GetFileInfo("/" + fullPath))
+                        .Returns(fileInfo);
+                }
+            }
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
@@ -1,17 +1,25 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
-using Moq;
 
 namespace WebOptimizer.Core.Test.Mocks
 {
     // grabbed the logic from https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
     // and made it recursive
-    internal static class MockFileProvider
+    internal class MockFileProvider : IFileProvider
     {
+        private readonly MockChangeToken _changeToken = new();
+        private readonly Dictionary<string, MockFileInfo> _files;
+        private readonly Dictionary<string, MockDirectoryContents> _directories;
+
+        private MockFileProvider(Dictionary<string, MockFileInfo> files, Dictionary<string, MockDirectoryContents> directories)
+        {
+            _files = files;
+            _directories = directories;
+        }
+
         public static IFileProvider Create(MockFileInfo rootNode)
         {
             if (rootNode.Files == null || !rootNode.Files.Any())
@@ -19,20 +27,11 @@ namespace WebOptimizer.Core.Test.Mocks
                 throw new ArgumentException($"{nameof(rootNode)} must have children.", nameof(rootNode));
             }
 
-            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
-            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>()))
-                .Returns((string p) => new NotFoundFileInfo(p));
-            SetupDirectoriesFiles(fileProvider, rootNode);
-            fileProvider.Setup(fp => fp.Watch(It.IsAny<string>()))
-                .Returns(new Mock<IChangeToken>().Object);
+            Dictionary<string, MockFileInfo> files = [];
+            Dictionary<string, MockDirectoryContents> directories = [];
 
-            return fileProvider.Object;
-        }
-
-        private static void SetupDirectoriesFiles(Mock<IFileProvider> fileProviderMock, MockFileInfo directory)
-        {
             var stack = new Stack<(MockFileInfo fileInfo, string directoryPath)>();
-            stack.Push((directory, string.Empty));
+            stack.Push((rootNode, string.Empty));
 
             while (stack.Count > 0)
             {
@@ -42,19 +41,9 @@ namespace WebOptimizer.Core.Test.Mocks
                 {
                     var children = fileInfo.Files;
 
-                    var directoryContents = new Mock<IDirectoryContents>();
-                    directoryContents.Setup(dc => dc.Exists).Returns(true);
-                    directoryContents.Setup(dc => dc.GetEnumerator())
-                        .Returns(() => children.GetEnumerator());
-                    directoryContents
-                        .As<IEnumerable>()
-                        .Setup(dc => dc.GetEnumerator())
-                        .Returns(() => children.GetEnumerator());
-
                     var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
 
-                    fileProviderMock.Setup(fp => fp.GetDirectoryContents(fullPath))
-                        .Returns(directoryContents.Object);
+                    directories[fullPath] = new MockDirectoryContents(children);
 
                     foreach (var child in children)
                     {
@@ -64,12 +53,27 @@ namespace WebOptimizer.Core.Test.Mocks
                 else
                 {
                     var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
-                    fileProviderMock.Setup(fp => fp.GetFileInfo(fullPath))
-                        .Returns(fileInfo);
-                    fileProviderMock.Setup(fp => fp.GetFileInfo("/" + fullPath))
-                        .Returns(fileInfo);
+                    files[fullPath] = fileInfo;
+                    files["/" + fullPath] = fileInfo;
                 }
             }
+
+            return new MockFileProvider(files, directories);
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            return _files.TryGetValue(subpath, out var fileInfo) ? fileInfo : new NotFoundFileInfo(subpath);
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+           return _directories.TryGetValue(subpath, out var directoryContents) ? directoryContents : new NotFoundDirectoryContents();
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            return _changeToken;
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
@@ -195,14 +195,6 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var env = new Mock<IWebHostEnvironment>();
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
             var cache = new Mock<IMemoryCache>();
-            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
-                .Returns((object key) =>
-                {
-                    var cacheEntry = new Mock<ICacheEntry>();
-                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
-
-                    return cacheEntry.Object;
-                });
             object cacheValue = "/file1.css?v=abc123";
             cache.Setup(c => c.TryGetValue("file1.css", out cacheValue)).Returns(true);
             object cacheValue2 = "/file2.css?v=def456";
@@ -210,17 +202,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             object cacheValue3 = "/sub/file3.css?v=ghi789";
             cache.Setup(c => c.TryGetValue("sub/file3.css", out cacheValue3)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
-            StringValues ae = "gzip, deflate";
-
-            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
-                .Returns(false)
-                .Returns(true);
-            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
-                .Returns(env.Object);
-            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
-                .Returns(cache.Object);
             context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
-            context.SetupGet(c => c.Items).Returns(new Dictionary<object, object>());
 
             var options = new WebOptimizerOptions
             {
@@ -228,7 +210,6 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
 
             var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
             var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
@@ -238,8 +219,6 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             var route = "/testbundle";
             var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.SetupGet(a => a.ContentType).Returns("text/css");
-            asset.SetupGet(a => a.Route).Returns(route);
             asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.css", "file2.css", "sub/file3.css"]));
             asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object> { { "fileprovider", fileProvider } });
@@ -270,6 +249,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue}\"", linkTags[0]);
             Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", linkTags[1]);
             Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue3}\"", linkTags[2]);
+
+            Mock.VerifyAll(context, cache, asset, assetPipeline);
         }
 
         [Theory2]

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Html;
@@ -12,6 +13,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using WebOptimizer.Core.Test.Mocks;
 using WebOptimizer.Taghelpers;
 using Xunit;
 
@@ -178,17 +180,35 @@ namespace WebOptimizer.Core.Test.TagHelpers
         [InlineData("", "/myapp")]
         public void CdnUrl_RouteIsAsset_TagHelperBundlingDisabled_Success(string cdnUrl, string pathBase)
         {
-            var fileInfo = new Mock<IFileInfo>();
-            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
-            var fileProvider = new Mock<IFileProvider>();
-            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var root =
+                MockFileInfo.CreateDirectory("", new DateTime(2017, 1, 1),
+                [
+                    new MockFileInfo("file1.css", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("body { background-color: red; }")),
+                    new MockFileInfo("file2.css", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("body { background-color: blue; }")),
+                    MockFileInfo.CreateDirectory("sub", new DateTime(2017, 1, 1),
+                    [
+                        new MockFileInfo("file3.css", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("body { background-color: green; }")),
+                    ]),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
             var env = new Mock<IWebHostEnvironment>();
-            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
             var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                .Returns((object key) =>
+                {
+                    var cacheEntry = new Mock<ICacheEntry>();
+                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                    return cacheEntry.Object;
+                });
             object cacheValue = "/file1.css?v=abc123";
             cache.Setup(c => c.TryGetValue("file1.css", out cacheValue)).Returns(true);
             object cacheValue2 = "/file2.css?v=def456";
             cache.Setup(c => c.TryGetValue("file2.css", out cacheValue2)).Returns(true);
+            object cacheValue3 = "/sub/file3.css?v=ghi789";
+            cache.Setup(c => c.TryGetValue("sub/file3.css", out cacheValue3)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
 
@@ -200,6 +220,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
             context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
+            context.SetupGet(c => c.Items).Returns(new Dictionary<object, object>());
 
             var options = new WebOptimizerOptions
             {
@@ -219,9 +240,9 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.css", "file2.css"]));
+            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.css", "file2.css", "sub/file3.css"]));
             asset.SetupGet(a => a.ExcludeFiles).Returns([]);
-            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object> { { "fileprovider", fileProvider.Object } });
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object> { { "fileprovider", fileProvider } });
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
             assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
@@ -245,9 +266,10 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] linkTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(2, linkTags.Length);
+            Assert.Equal(3, linkTags.Length);
             Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue}\"", linkTags[0]);
             Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", linkTags[1]);
+            Assert.Contains($"href=\"{options.CdnUrl}{pathBase}{cacheValue3}\"", linkTags[2]);
         }
 
         [Theory2]

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Html;
@@ -12,6 +13,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using WebOptimizer.Core.Test.Mocks;
 using WebOptimizer.Taghelpers;
 using Xunit;
 
@@ -173,17 +175,35 @@ namespace WebOptimizer.Core.Test.TagHelpers
         [InlineData("", "/myapp")]
         public void CdnUrl_RouteIsAsset_TagHelperBundlingDisabled_Success(string cdnUrl, string pathBase)
         {
-            var fileInfo = new Mock<IFileInfo>();
-            fileInfo.SetupGet(fi => fi.Exists).Returns(true);
-            var fileProvider = new Mock<IFileProvider>();
-            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>())).Returns(fileInfo.Object);
+            var root =
+                MockFileInfo.CreateDirectory("", new DateTime(2017, 1, 1),
+                [
+                    new MockFileInfo("file1.js", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("console.log('file1.js');")),
+                    new MockFileInfo("file2.js", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("console.log('file2.js');")),
+                    MockFileInfo.CreateDirectory("sub", new DateTime(2017, 1, 1),
+                    [
+                        new MockFileInfo("file3.js", new DateTime(2017, 1, 1), Encoding.UTF8.GetBytes("console.log('file3.js');")),
+                    ]),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
             var env = new Mock<IWebHostEnvironment>();
-            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
             var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                .Returns((object key) =>
+                {
+                    var cacheEntry = new Mock<ICacheEntry>();
+                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                    return cacheEntry.Object;
+                });
             object cacheValue = "/file1.js?v=abc123";
             cache.Setup(c => c.TryGetValue("file1.js", out cacheValue)).Returns(true);
             object cacheValue2 = "/file2.js?v=def456";
             cache.Setup(c => c.TryGetValue("file2.js", out cacheValue2)).Returns(true);
+            object cacheValue3 = "/sub/file3.js?v=ghi789";
+            cache.Setup(c => c.TryGetValue("sub/file3.js", out cacheValue3)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
             StringValues ae = "gzip, deflate";
             
@@ -195,6 +215,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
                 .Returns(cache.Object);
             context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
+            context.SetupGet(c => c.Items).Returns(new Dictionary<object, object>());
             
             var options = new WebOptimizerOptions
             {
@@ -214,9 +235,9 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/javascript");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.js", "file2.js"]));
+            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.js", "file2.js", "sub/file3.js"]));
             asset.SetupGet(a => a.ExcludeFiles).Returns([]);
-            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
+            asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider}});
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
             assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(route, out assetObject)).Returns(true);
@@ -240,9 +261,10 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] scriptTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
-            Assert.Equal(2, scriptTags.Length);
+            Assert.Equal(3, scriptTags.Length);
             Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue}\"", scriptTags[0]);
             Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", scriptTags[1]);
+            Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue3}\"", scriptTags[2]);
         }
 
         [Theory2]

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
@@ -190,14 +190,6 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var env = new Mock<IWebHostEnvironment>();
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
             var cache = new Mock<IMemoryCache>();
-            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
-                .Returns((object key) =>
-                {
-                    var cacheEntry = new Mock<ICacheEntry>();
-                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
-
-                    return cacheEntry.Object;
-                });
             object cacheValue = "/file1.js?v=abc123";
             cache.Setup(c => c.TryGetValue("file1.js", out cacheValue)).Returns(true);
             object cacheValue2 = "/file2.js?v=def456";
@@ -205,26 +197,15 @@ namespace WebOptimizer.Core.Test.TagHelpers
             object cacheValue3 = "/sub/file3.js?v=ghi789";
             cache.Setup(c => c.TryGetValue("sub/file3.js", out cacheValue3)).Returns(true);
             var context = new Mock<HttpContext>().SetupAllProperties();
-            StringValues ae = "gzip, deflate";
-            
-            context.SetupSequence(c => c.Request.Headers.TryGetValue("Accept-Encoding", out ae))
-                .Returns(false)
-                .Returns(true);
-            context.Setup(c => c.RequestServices.GetService(typeof(IWebHostEnvironment)))
-                .Returns(env.Object);
-            context.Setup(c => c.RequestServices.GetService(typeof(IMemoryCache)))
-                .Returns(cache.Object);
             context.SetupGet(c => c.Request.PathBase).Returns(pathBase);
-            context.SetupGet(c => c.Items).Returns(new Dictionary<object, object>());
-            
+
             var options = new WebOptimizerOptions
             {
                 EnableTagHelperBundling = false,
                 CdnUrl = cdnUrl
             };
             var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-            
+
             var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
             var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
             
@@ -233,8 +214,6 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             var route = "/testbundle";
             var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.SetupGet(a => a.ContentType).Returns("text/javascript");
-            asset.SetupGet(a => a.Route).Returns(route);
             asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.js", "file2.js", "sub/file3.js"]));
             asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider}});
@@ -265,6 +244,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue}\"", scriptTags[0]);
             Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue2}\"", scriptTags[1]);
             Assert.Contains($"src=\"{options.CdnUrl}{pathBase}{cacheValue3}\"", scriptTags[2]);
+
+            Mock.VerifyAll(context, cache, asset, assetPipeline);
         }
 
         [Theory2]


### PR DESCRIPTION
Update 2026-06-11: I've replaced manual caching with [GlobbingUrlBuilder](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.globbingurlbuilder?view=aspnetcore-8.0). Plus, I've added two more tests to check that GlobbingUrlBuilder works with nested directories/files.

---

At the moment, `Asset.ExpandGlobs`{:.c#} doesn't cache results of `provider.GetAllFiles("/")`, so in the following example (simplified example - in the real app, this bundle contains different globs at different nested levels):

```c#
builder
    .Services
    .AddWebOptimizer(
        pipeline =>
        {
            //...
            pipeline.AddJavaScriptBundle(
                "bundle1",
                "js/*",
                "js/*",
                "js/*",
                "js/*",
                "js/*",
                "js/*");
            //...
        },
        options =>
        {
            options.EnableTagHelperBundling = false;
        });
```

`Asset.ExpandGlobs` will get all files 6 times. It can be a problem, if the virtual files hierarchy is huge.

This PR caches the results of `provider.GetAllFiles("/")` per `provider` into `HttpContext.Items` dictionary.

Also, this fixes the case when many complex bundles are located on the same page, e.g.:

```razor
...
<script src="~/bundle1"></script>
<script src="~/bundle2"></script>
<script src="~/bundle3"></script>
...
```

Each of them will reuse the cached file hierarchy if possible.

P.S. As you can see, I've tested this with `EnableTagHelperBundling = false`. `ScriptTagHelper` and `LinkTagHelper` call `Asset.ExpandGlobs` on each execution, which resulted in 5 seconds of rendering for just the script tags in my app, instead of something like ~0.1 seconds. :)