### PR TITLE
Fix #329  Do not replace the attribute if  we are not changing its value

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptTagHelper.cs
@@ -75,10 +75,9 @@ namespace WebOptimizer.Taghelpers
                 if (!Uri.TryCreate(src, UriKind.Absolute, out Uri _))
                 {
                     src = AddCdn(AddPathBase(src));
+                    output.Attributes.SetAttribute("src", src);
                 }
-                output.Attributes.SetAttribute("src", src);
             }
-
         }
 
         private void WriteIndividualTags(TagHelperOutput output, IAsset asset)


### PR DESCRIPTION
The Script Tag Helper replaces the src attribute even if its value doesn't change. That will replace an HTMLString with a string. That will cause it to be re-encoded.   This fixes the issue I'm seeing. I did not look for other issues in the Link tag helper. 