### PR TITLE
Fixes a bug that was introduced for relative urls

### DIFF
--- a/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
+++ b/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
@@ -55,7 +55,7 @@ namespace WebOptimizer
                     ? config.HttpContext.Request.PathBase.Value
                     : "/";
 
-                string routePath = UrlPathUtils.MakeAbsolute(appPath, config.Asset.Route.TrimStart('/'));
+                string routePath = UrlPathUtils.MakeAbsolute(appPath, config.Asset.Route);
 
                 // prevent query string from causing error
                 string[] pathAndQuery = urlValue.Split(new[] { '?' }, 2, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Commit bf0933112a3ede2077bc9df4fe4a6f757b1daa7e causes a bug in relative urls so that certain resources inside css-files are not referenced correctly. Fixes issue #325 reported by many. Though since I don't know the intent of the code in that commit, I cannot say why breaking "TrimStart" was added and does my change affect something else. Also there IS a problem with the test in RelativePathAdjusterTest.cs since it does not find this bug. The test passes with or without my commit and that should not be so. Some test is missing but I do not have enough knowledge to add missing tests.