### PR TITLE
Update NUglify package version to 1.21.15 (latest) - fix #337

### DIFF
--- a/src/WebOptimizer.Core/WebOptimizer.Core.csproj
+++ b/src/WebOptimizer.Core/WebOptimizer.Core.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="NUglify" Version="1.21.9" />
+    <PackageReference Include="NUglify" Version="1.21.15" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Build/$(PackageId).targets">


### PR DESCRIPTION
**Description**
This pull request updates **NUglify** nuget package to latest version 1.21.15. 
The new version adds support for the CSS minification with clamp function and the "+" operator, along with other improvements and corrections.

**Related Issue**
Fixes issue #337.

**Related Issue on NUglify**
Fixes issue https://github.com/trullock/NUglify/issues/424 (fixed).

**Testing**
All existing css related tests passed