### PR TITLE
Add cache-control public or private directives

### DIFF
--- a/sample2/WebOptimizer.Core.Sample2/Startup.cs
+++ b/sample2/WebOptimizer.Core.Sample2/Startup.cs
@@ -32,7 +32,7 @@ namespace WebOptimizer.Core.Sample2
                 Minify = true,
             };
 
-            services.AddWebOptimizer(HostingEnvironment, cssSettings, codeSettings);
+            services.AddWebOptimizer(HostingEnvironment, cssSettings, codeSettings, options => options.CacheControlAccess = HttpResponseCacheControlAccessDirective.Public);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/WebOptimizer.Core/AssetMiddleware.cs
+++ b/src/WebOptimizer.Core/AssetMiddleware.cs
@@ -28,7 +28,7 @@ namespace WebOptimizer
 
             if (context.Request.PathBase.HasValue)
             {
-                string pathBase = context.Request.PathBase.Value;
+                string pathBase = context.Request.PathBase.Value!;
                 if (context.Request.Path.StartsWithSegments(pathBase))
                 {
                     path = path.Substring(pathBase.Length);
@@ -88,7 +88,7 @@ namespace WebOptimizer
             {
                 if (options.EnableCaching == true)
                 {
-                    context.Response.Headers[HeaderNames.CacheControl] = "max-age=31536000,immutable"; // 1 year, immutable
+                    context.Response.Headers[HeaderNames.CacheControl] = $"{(options.CacheControlAccess != null ? $"{options.CacheControlAccess}," : string.Empty)}max-age=31536000,immutable"; // 1 year, immutable
                 }
 
                 context.Response.Headers[HeaderNames.ETag] = $"\"{cacheKey}\"";
@@ -100,7 +100,7 @@ namespace WebOptimizer
                 }
             }
 
-            if (cachedResponse?.Body?.Length > 0)
+            if (cachedResponse.Body?.Length > 0)
             {
                 SetCompressionMode(context, options);
                 await context.Response.Body.WriteAsync(cachedResponse.Body, 0, cachedResponse.Body.Length);

--- a/src/WebOptimizer.Core/HttpResponseCacheControlAccessDirective.cs
+++ b/src/WebOptimizer.Core/HttpResponseCacheControlAccessDirective.cs
@@ -1,0 +1,20 @@
+namespace WebOptimizer;
+
+/// <summary>
+/// RFC-9111 HTTP Caching defines support for HTTP response cache-control directives 'private' and 'public'.
+/// </summary>
+/// <remarks>
+/// See https://www.rfc-editor.org/rfc/rfc9111#name-private
+/// See https://www.rfc-editor.org/rfc/rfc9111#name-public
+/// </remarks>
+public enum HttpResponseCacheControlAccessDirective
+{
+    /// <summary>
+    /// See https://www.rfc-editor.org/rfc/rfc9111#name-private
+    /// </summary>
+    Private = 0,
+    /// <summary>
+    /// See https://www.rfc-editor.org/rfc/rfc9111#name-public
+    /// </summary>
+    Public
+}

--- a/src/WebOptimizer.Core/WebOptimizerOptions.cs
+++ b/src/WebOptimizer.Core/WebOptimizerOptions.cs
@@ -9,6 +9,14 @@ namespace WebOptimizer
     public class WebOptimizerOptions : IWebOptimizerOptions
     {
         /// <summary>
+        /// Gets or sets a value indicating whether the cache is private, public or unspecified.
+        /// </summary>
+        /// <remarks>
+        /// For performance, recommendation is to set to <see cref="HttpResponseCacheControlAccessDirective.Public" />.
+        /// </remarks>
+        public HttpResponseCacheControlAccessDirective? CacheControlAccess { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether server-side caching is enabled.
         /// Default is <code>false</code> when running in a development environment.
         /// </summary>


### PR DESCRIPTION
Fixes #274 and #294

@madskristensen This was an easy one, although there are no AssetMiddleware tests currently. I think the change is pretty minor but will result in a significant performance improvement for many users. If you like it and would be willing to do a Major Version release, we can also set the default to be Public.