### PR TITLE
File Not Found should be Information-level log message

### DIFF
--- a/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
@@ -26,7 +26,7 @@ namespace WebOptimizer
             eventId: 1004,
             formatString: "No response generated for '{Path}'. Passing on to next middleware.");
         private static Action<ILogger, string, Exception> _logFileNotFound = LoggerMessage.Define<string>(
-            logLevel: LogLevel.Warning,
+            logLevel: LogLevel.Information,
             eventId: 1005,
             formatString: "File '{Path}' not found. Passing on to next middleware.");
         


### PR DESCRIPTION
When a file is not found via user request, it should be an Information-level log message (e.g., stale static content that has been deleted from a high traffic website)

Fixes #336
