### PR TITLE
Update xunit tests to use appropriate style (Fixes #353)

### DIFF
--- a/WebOptimizer.sln
+++ b/WebOptimizer.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29209.152
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebOptimizer.Core", "src\WebOptimizer.Core\WebOptimizer.Core.csproj", "{FCB6608A-3219-44ED-A400-A735EEB33C40}"
 EndProject

--- a/sample2/WebOptimizer.Core.Sample2/Startup.cs
+++ b/sample2/WebOptimizer.Core.Sample2/Startup.cs
@@ -53,8 +53,7 @@ namespace WebOptimizer.Core.Sample2
             const string scriptsPath2 = "Scripts2";
 
             var currentDirectory = Directory.GetCurrentDirectory();
-            app.UseWebOptimizer(HostingEnvironment, new[]
-            {
+            app.UseWebOptimizer(HostingEnvironment, [
                 new FileProviderOptions
                 {
                     RequestPath = "/" + scriptsPath1,
@@ -70,7 +69,7 @@ namespace WebOptimizer.Core.Sample2
                     RequestPath = "/EmbeddedResourcesScripts",
                     FileProvider = new EmbeddedFileProvider(Lib.AssemblyTools.GetCurrentAssembly()),
                 }
-            });
+            ]);
 
             app.UseStaticFiles();
 

--- a/src/WebOptimizer.Core/Asset.cs
+++ b/src/WebOptimizer.Core/Asset.cs
@@ -23,7 +23,7 @@ namespace WebOptimizer
     {
         private readonly ILogger<Asset> _logger;
         internal const string PhysicalFilesKey = "PhysicalFiles";
-        private readonly object _sync = new object();
+        private readonly object _sync = new();
 
         public Asset(string route, string contentType, IEnumerable<string> sourceFiles, ILogger<Asset> logger)
         {
@@ -31,20 +31,19 @@ namespace WebOptimizer
             Route = route ?? throw new ArgumentNullException(nameof(route));
             ContentType = contentType ?? throw new ArgumentNullException(nameof(contentType));
             SourceFiles = sourceFiles?.ToList() ?? throw new ArgumentNullException(nameof(sourceFiles));
-            Processors = new List<IProcessor>();
             Items = new ConcurrentDictionary<string, object>();
             _logger = logger;
         }
 
         public string Route { get; private set; }
 
-        public IList<string> ExcludeFiles { get; } = new List<string>();
+        public IList<string> ExcludeFiles { get; } = [];
 
         public IList<string> SourceFiles { get; }
 
         public string ContentType { get; private set; }
 
-        public IList<IProcessor> Processors { get; }
+        public IList<IProcessor> Processors { get; } = [];
 
         public IDictionary<string, object> Items { get; }
 
@@ -143,7 +142,7 @@ namespace WebOptimizer
         {
             IFileInfo file = fileProvider.GetFileInfo(sourceFile);
 
-            using (Stream fs = file.CreateReadStream())
+            await using (Stream fs = file.CreateReadStream())
             {
                 byte[] bytes = await fs.AsBytesAsync();
 

--- a/src/WebOptimizer.Core/AssetBuilder.cs
+++ b/src/WebOptimizer.Core/AssetBuilder.cs
@@ -14,9 +14,9 @@ namespace WebOptimizer
     /// <seealso cref="WebOptimizer.IAssetBuilder" />
     internal class AssetBuilder : IAssetBuilder
     {
-        private IMemoryCache _cache;
-        private ILogger<AssetBuilder> _logger;
-        private IWebHostEnvironment _env;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<AssetBuilder> _logger;
+        private readonly IWebHostEnvironment _env;
         private readonly IAssetResponseStore _assetResponseCache;
 
         /// <summary>

--- a/src/WebOptimizer.Core/AssetPipeline.cs
+++ b/src/WebOptimizer.Core/AssetPipeline.cs
@@ -9,7 +9,7 @@ namespace WebOptimizer
 {
     internal class AssetPipeline : IAssetPipeline
     {
-        internal ConcurrentDictionary<string, IAsset> _assets = new ConcurrentDictionary<string, IAsset>(StringComparer.OrdinalIgnoreCase);
+        internal ConcurrentDictionary<string, IAsset> _assets = new(StringComparer.OrdinalIgnoreCase);
         /// <summary>
         /// For use by the Asset constructor only. Do not use for logging messages inside <see cref="AssetPipeline"/>.
         /// </summary>
@@ -56,10 +56,9 @@ namespace WebOptimizer
 
                     if (result.HasMatches)
                     {
-                        asset = new Asset(cleanRoute, existing.ContentType, new[]
-                        {
+                        asset = new Asset(cleanRoute, existing.ContentType, [
                             cleanRoute
-                        }, _assetLogger);
+                        ], _assetLogger);
 
                         foreach (IProcessor processor in existing.Processors)
                         {
@@ -128,7 +127,7 @@ namespace WebOptimizer
         {
             route = NormalizeRoute(route);
 
-            IAsset asset = new Asset(route, contentType, new string[0], _assetLogger);
+            IAsset asset = new Asset(route, contentType, Array.Empty<string>(), _assetLogger);
             _assets.TryAdd(route, asset);
 
             return asset;
@@ -165,7 +164,7 @@ namespace WebOptimizer
                 ? "/" + route.Trim().TrimStart('~', '/')
                 : trimmedRoute;
 
-            int index = cleanRoute.IndexOfAny(new[] { '?', '#' });
+            int index = cleanRoute.IndexOfAny(['?', '#']);
 
             if (index > -1)
             {

--- a/src/WebOptimizer.Core/AssetResponseStore.cs
+++ b/src/WebOptimizer.Core/AssetResponseStore.cs
@@ -13,7 +13,7 @@ namespace WebOptimizer
     {
         private readonly ILogger<AssetResponseStore> _logger;
         private readonly IWebHostEnvironment _env;
-        private readonly WebOptimizerOptions _options = new WebOptimizerOptions();
+        private readonly WebOptimizerOptions _options = new();
 
         public AssetResponseStore(ILogger<AssetResponseStore> logger, IWebHostEnvironment env, IConfigureOptions<WebOptimizerOptions> options)
         {

--- a/src/WebOptimizer.Core/Extensions/CodeBundlingSettings.cs
+++ b/src/WebOptimizer.Core/Extensions/CodeBundlingSettings.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public CodeSettings CodeSettings { get; } = new CodeSettings();
         public bool Minify { get; set; } = true;
-        public string[] EnforceFileExtensions { get; set; } = {".js"};
+        public string[] EnforceFileExtensions { get; set; } = [".js"];
         public bool AdjustRelativePaths { get; set; } = true;
         public bool Concatenate { get; set; } = true;
     }

--- a/src/WebOptimizer.Core/Extensions/CssBundlingSettings.cs
+++ b/src/WebOptimizer.Core/Extensions/CssBundlingSettings.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public CssSettings CssSettings { get; } = new CssSettings();
         public bool Minify { get; set; } = true;
-        public string[] EnforceFileExtensions { get; set; } = {".css"};
+        public string[] EnforceFileExtensions { get; set; } = [".css"];
         public bool AdjustRelativePaths { get; set; } = true;
         public bool Concatenate { get; set; } = true;
         public bool FingerprintUrls { get; set; } = true;

--- a/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/LoggerExtensions.cs
@@ -5,31 +5,31 @@ namespace WebOptimizer
 {
     internal static class LoggerExtensions
     {
-        private static Action<ILogger, string, Exception> _logRequestForAssetStarted = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logRequestForAssetStarted = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1000,
             formatString: "Request started for '{Path}'");
-        private static Action<ILogger, string, Exception> _logServedFromMemoryCache = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logServedFromMemoryCache = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1001,
             formatString: "Responding from memory cache for '{Path}'");
-        private static Action<ILogger, string, Exception> _logServedFromDiskCache = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logServedFromDiskCache = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1002,
             formatString: "Responding from disk cache for '{Path}'");
-        private static Action<ILogger, string, Exception> _logGeneratedOutput = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logGeneratedOutput = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1003,
             formatString: "Generated output and responded to request for '{Path}'");
-        private static Action<ILogger, string, Exception> _logZeroByteResponse = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logZeroByteResponse = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1004,
             formatString: "No response generated for '{Path}'. Passing on to next middleware.");
-        private static Action<ILogger, string, Exception> _logFileNotFound = LoggerMessage.Define<string>(
+        private static readonly Action<ILogger, string, Exception> _logFileNotFound = LoggerMessage.Define<string>(
             logLevel: LogLevel.Information,
             eventId: 1005,
             formatString: "File '{Path}' not found. Passing on to next middleware.");
-        private static Action<ILogger, string, string, Exception> _logSourceFileAlreadyAdded = LoggerMessage.Define<string, string>(
+        private static readonly Action<ILogger, string, string, Exception> _logSourceFileAlreadyAdded = LoggerMessage.Define<string, string>(
             logLevel: LogLevel.Information,
             eventId: 1006,
             formatString: "Source file route '{SourceFileRoute}' already added as clean route '{SourceFileCleanRoute}'.");

--- a/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
+++ b/src/WebOptimizer.Core/Extensions/ServiceExtensions.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServiceExtensions
     {
-        internal static CssBundlingSettings CssBundlingSettings = new CssBundlingSettings();
+        internal static CssBundlingSettings CssBundlingSettings = new();
 
-        internal static CodeBundlingSettings CodeBundlingSettings = new CodeBundlingSettings();
+        internal static CodeBundlingSettings CodeBundlingSettings = new();
 
         /// <summary>
         /// Adds WebOptimizer to the specified <see cref="IServiceCollection"/> and enables CSS and JavaScript minification.
@@ -155,9 +155,8 @@ namespace Microsoft.Extensions.DependencyInjection
         private static void UpdateCssAndCodeBundlingSettings(IServiceCollection services,
             CssBundlingSettings cssBundlingSettings, CodeBundlingSettings codeBundlingSettings)
         {
-            if (cssBundlingSettings == null) throw new ArgumentNullException(nameof(cssBundlingSettings));
-            if (codeBundlingSettings == null) throw new ArgumentNullException(nameof(codeBundlingSettings));
-
+            ArgumentNullException.ThrowIfNull(cssBundlingSettings);
+            ArgumentNullException.ThrowIfNull(codeBundlingSettings);
             CssBundlingSettings = cssBundlingSettings;
             CodeBundlingSettings = codeBundlingSettings;
 

--- a/src/WebOptimizer.Core/Processors/CssFingerprinter.cs
+++ b/src/WebOptimizer.Core/Processors/CssFingerprinter.cs
@@ -58,7 +58,7 @@ namespace WebOptimizer
                 string routeBasePath = UrlPathUtils.GetDirectory(config.Asset.Route);
 
                 // prevent query string from causing error
-                string[] pathAndQuery = urlValue.Split(new[] { '?' }, 2, StringSplitOptions.RemoveEmptyEntries);
+                string[] pathAndQuery = urlValue.Split(['?'], 2, StringSplitOptions.RemoveEmptyEntries);
                 string pathOnly = pathAndQuery[0];
                 string queryOnly = pathAndQuery.Length == 2 ? pathAndQuery[1] : string.Empty;
 
@@ -114,7 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Adds a fingerprint to local url() references.
-        /// NOTE: Make sure to call this method before Concatenate()
+        /// NOTE: Make sure to call this method before Concatinate()
         /// </summary>
         public static IAsset FingerprintUrls(this IAsset bundle)
         {
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Adds a fingerprint to local url() references.
-        /// NOTE: Make sure to call this method before Concatenate()
+        /// NOTE: Make sure to call this method before Concatinate()
         /// </summary>
         public static IEnumerable<IAsset> FingerprintUrls(this IEnumerable<IAsset> assets)
         {

--- a/src/WebOptimizer.Core/Processors/CssImageInliner.cs
+++ b/src/WebOptimizer.Core/Processors/CssImageInliner.cs
@@ -78,7 +78,7 @@ namespace WebOptimizer
             string routeBasePath = UrlPathUtils.GetDirectory(config.Asset.Route);
 
             // prevent query string from causing error
-            string[] pathAndQuery = urlValue.Split(new[] { '?' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            string[] pathAndQuery = urlValue.Split(['?'], 2, StringSplitOptions.RemoveEmptyEntries);
             string pathOnly = pathAndQuery[0];
             string queryOnly = pathAndQuery.Length == 2 ? pathAndQuery[1] : string.Empty;
 
@@ -174,7 +174,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Adds a fingerprint to local url() references.
-        /// NOTE: Make sure to call Concatenate() before this method
+        /// NOTE: Make sure to call Concatinate() before this method
         /// </summary>
         public static IEnumerable<IAsset> InlineImages(this IEnumerable<IAsset> assets, int maxFileSize = 5120)
         {

--- a/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
+++ b/src/WebOptimizer.Core/Processors/RelativePathAdjuster.cs
@@ -58,7 +58,7 @@ namespace WebOptimizer
                 string routePath = UrlPathUtils.MakeAbsolute(appPath, config.Asset.Route.TrimStart('/'));
 
                 // prevent query string from causing error
-                string[] pathAndQuery = urlValue.Split(new[] { '?' }, 2, StringSplitOptions.RemoveEmptyEntries);
+                string[] pathAndQuery = urlValue.Split(['?'], 2, StringSplitOptions.RemoveEmptyEntries);
                 string pathOnly = pathAndQuery[0];
                 string queryOnly = pathAndQuery.Length == 2 ? ("?" + pathAndQuery[1]) : string.Empty;
 

--- a/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -15,7 +14,7 @@ namespace WebOptimizer.Taghelpers
     [HtmlTargetElement("script", Attributes = "inline")]
     public class ScriptInlineSrcTagHelper : BaseTagHelper
     {
-        private IAssetBuilder _builder;
+        private readonly IAssetBuilder _builder;
 
         /// <summary>
         /// Tag helper for inlining content

--- a/src/WebOptimizer.Core/Utils/UrlPathUtils.cs
+++ b/src/WebOptimizer.Core/Utils/UrlPathUtils.cs
@@ -24,7 +24,7 @@ namespace WebOptimizer.Utils
 
         public static bool TryNormalize(string path, out string normalizedPath)
         {
-            List<string> normalized = new List<string>();
+            List<string> normalized = [];
 
             foreach (StringSegment segment in new StringTokenizer(path, ['/']))
             {
@@ -123,7 +123,7 @@ namespace WebOptimizer.Utils
             if (path.EndsWith("/"))
                 return path;
 
-            StringTokenizer segments = new StringTokenizer(path, new[] { '/' });
+            StringTokenizer segments = new StringTokenizer(path, ['/']);
 
             string directory = string.Join('/', segments.SkipLast(1)) + "/";
 
@@ -144,7 +144,7 @@ namespace WebOptimizer.Utils
             if (path.EndsWith("/"))
                 throw new ArgumentException("Path is a directory");
 
-            StringTokenizer segments = new StringTokenizer(path, new[] { '/' });
+            StringTokenizer segments = new StringTokenizer(path, ['/']);
 
             return segments.Last().Value;
         }

--- a/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetBuilderTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -32,7 +31,7 @@ namespace WebOptimizer.Core.Test
 
             StringValues values;
             var response = new Mock<HttpResponse>().SetupAllProperties();
-            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            response.Setup(r => r.Headers.Keys).Returns([]);
             var context = new Mock<HttpContext>().SetupAllProperties();
             context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
             context.Setup(c => c.Response).Returns(response.Object);
@@ -70,7 +69,7 @@ namespace WebOptimizer.Core.Test
             var pipeline = new AssetPipeline();
             var options = new WebOptimizerOptions() { EnableDiskCache = false };
             var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns([]);
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("cachekey");
@@ -79,7 +78,7 @@ namespace WebOptimizer.Core.Test
 
             StringValues values;
             var response = new Mock<HttpResponse>().SetupAllProperties();
-            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            response.Setup(r => r.Headers.Keys).Returns([]);
             var context = new Mock<HttpContext>().SetupAllProperties();
             context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
             context.Setup(c => c.Response).Returns(response.Object);
@@ -116,7 +115,7 @@ namespace WebOptimizer.Core.Test
             var pipeline = new AssetPipeline();
             var options = new WebOptimizerOptions() { EnableMemoryCache = false, EnableDiskCache = false };
             var asset = new Mock<IAsset>().SetupAllProperties();
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns([]);
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns("/file.css");
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), options)).Returns("cachekey");
@@ -125,7 +124,7 @@ namespace WebOptimizer.Core.Test
 
             StringValues values;
             var response = new Mock<HttpResponse>().SetupAllProperties();
-            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            response.Setup(r => r.Headers.Keys).Returns([]);
             var context = new Mock<HttpContext>().SetupAllProperties();
             context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
             context.Setup(c => c.Response).Returns(response.Object);
@@ -163,7 +162,7 @@ namespace WebOptimizer.Core.Test
 
             StringValues values;
             var response = new Mock<HttpResponse>().SetupAllProperties();
-            response.Setup(r => r.Headers.Keys).Returns(new string[] { });
+            response.Setup(r => r.Headers.Keys).Returns([]);
             var context = new Mock<HttpContext>().SetupAllProperties();
             context.Setup(s => s.Request.Headers.TryGetValue("Accept-Encoding", out values)).Returns(false);
             context.Setup(c => c.Response).Returns(response.Object);

--- a/test/WebOptimizer.Core.Test/AssetContextTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetContextTest.cs
@@ -22,7 +22,7 @@ namespace WebOptimizer.Test
 
             Assert.Equal(asset, assetContext.Asset);
             Assert.Equal(httpContext, assetContext.HttpContext);
-            Assert.Equal(0, assetContext.Content.Count);
+            Assert.Empty(assetContext.Content);
         }
 
         [Fact2]

--- a/test/WebOptimizer.Core.Test/AssetTest.cs
+++ b/test/WebOptimizer.Core.Test/AssetTest.cs
@@ -26,7 +26,7 @@ namespace WebOptimizer.Test
             Assert.Equal(route, asset.Route);
             Assert.Equal(contentType, asset.ContentType);
             Assert.Equal(sourcefiles, asset.SourceFiles);
-            Assert.Equal(0, asset.Processors.Count);
+            Assert.Empty(asset.Processors);
         }
 
         [Fact2]
@@ -42,7 +42,7 @@ namespace WebOptimizer.Test
             Assert.Equal(route, asset.Route);
             Assert.Equal(contentType, asset.ContentType);
             Assert.Equal(sourcefiles, asset.SourceFiles);
-            Assert.Equal(0, asset.Processors.Count);
+            Assert.Empty(asset.Processors);
         }
 
 
@@ -90,7 +90,7 @@ namespace WebOptimizer.Test
         public void AssetToString()
         {
             var logger = new Mock<ILogger<Asset>>();
-            var asset = new Asset("/route", "content/type", Enumerable.Empty<string>(), logger.Object);
+            var asset = new Asset("/route", "content/type", [], logger.Object);
 
             Assert.Equal(asset.Route, asset.ToString());
         }

--- a/test/WebOptimizer.Core.Test/Processors/ConcatenatorTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/ConcatenatorTest.cs
@@ -24,7 +24,7 @@ namespace WebOptimizer.Test.Processors
 
             await processor.ExecuteAsync(context.Object);
 
-            Assert.Equal(1, context.Object.Content.Count);
+            Assert.Single(context.Object.Content);
             Assert.Equal("content\r\ncontent2\r\n", context.Object.Content.Values.First().AsString());
         }
 
@@ -38,7 +38,7 @@ namespace WebOptimizer.Test.Processors
 
             await processor.ExecuteAsync(context.Object);
 
-            Assert.Equal(1, context.Object.Content.Count);
+            Assert.Single(context.Object.Content);
             Assert.Equal(string.Empty, context.Object.Content.Values.First().AsString());
         }
 
@@ -47,11 +47,10 @@ namespace WebOptimizer.Test.Processors
         {
             var env = new HostingEnvironment { EnvironmentName = "Development" };
             var logger = new Mock<ILogger<Asset>>();
-            var asset1 = new Asset("/file1", "text/css", new[] { "file.css" }, logger.Object);
-            var asset2 = new Asset("/file2", "text/css", new[] { "file.css" }, logger.Object);
-            var pipeline = new AssetPipeline();
-            pipeline._assetLogger = logger.Object;
-            var assets = pipeline.AddBundle(new[] { asset1, asset2 });
+            var asset1 = new Asset("/file1", "text/css", ["file.css"], logger.Object);
+            var asset2 = new Asset("/file2", "text/css", ["file.css"], logger.Object);
+            var pipeline = new AssetPipeline { _assetLogger = logger.Object };
+            var assets = pipeline.AddBundle([asset1, asset2]);
 
             assets = assets.Concatenate();
 
@@ -59,7 +58,7 @@ namespace WebOptimizer.Test.Processors
 
             foreach (var asset in assets)
             {
-                Assert.Equal(1, asset.Processors.Count);
+                Assert.Single(asset.Processors);
                 Assert.True(asset.Processors.First() is Concatenator);
             }
         }

--- a/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/CssMinifierTest.cs
@@ -127,8 +127,8 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/**/*.css", asset.Route);
             Assert.Equal("text/css; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count);
-            Assert.True(3 == asset.Processors.Count);
+            Assert.Single(asset.SourceFiles);
+            Assert.Equal(3, asset.Processors.Count);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/HtmlMinifierTest.cs
@@ -115,8 +115,8 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/**/*.html", asset.Route);
             Assert.Equal("text/html; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count);
-            Assert.True(1 == asset.Processors.Count);
+            Assert.Single(asset.SourceFiles);
+            Assert.Single(asset.Processors);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/JavaScriptMinifierTest.cs
@@ -115,8 +115,8 @@ namespace WebOptimizer.Test.Processors
 
             Assert.Equal("/**/*.js", asset.Route);
             Assert.Equal("text/javascript; charset=UTF-8", asset.ContentType);
-            Assert.True(1 == asset.SourceFiles.Count);
-            Assert.True(2 == asset.Processors.Count);
+            Assert.Single(asset.SourceFiles);
+            Assert.Equal(2, asset.Processors.Count);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/Processors/UseContentRootTest.cs
+++ b/test/WebOptimizer.Core.Test/Processors/UseContentRootTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -13,11 +12,11 @@ namespace WebOptimizer.Test.Processors
         {
             var minifier = new UseContentRoot();
             var logger = new Mock<ILogger<Asset>>();
-            var asset = new Asset("", "", new[] { "" }, logger.Object);
+            var asset = new Asset("", "", [""], logger.Object);
 
-            Assert.Equal(0, asset.Items.Count);
+            Assert.Empty(asset.Items);
             asset.UseContentRoot();
-            Assert.Equal(1, asset.Items.Count);
+            Assert.Single(asset.Items);
         }
 
         [Fact2]
@@ -25,11 +24,11 @@ namespace WebOptimizer.Test.Processors
         {
             var minifier = new UseContentRoot();
             var logger = new Mock<ILogger<Asset>>();
-            var asset = new Asset("", "", new[] { "" }, logger.Object);
+            var asset = new Asset("", "", [""], logger.Object);
 
-            Assert.Equal(0, asset.Items.Count);
+            Assert.Empty(asset.Items);
             asset.UseFileProvider(null);
-            Assert.Equal(1, asset.Items.Count);
+            Assert.Single(asset.Items);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkTagHelperTest.cs
@@ -73,8 +73,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(new[] { "file.css" }));
-            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns([..new[] { "file.css" }]);
+            asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object> { { "fileprovider", fileProvider.Object } });
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
                 .Returns(cacheKey);
@@ -97,7 +97,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
 
-            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var hrefAttr = tagHelperOutput.Attributes.First(x => x.Name == "href");
@@ -164,7 +164,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var hrefValue = $"{pathBase}/lib/bootstrap/dist/css/bootstrap.min.css";
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", hrefValue) };
 
-            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var hrefAttr = tagHelperOutput.Attributes.First(x => x.Name == "href");
@@ -219,8 +219,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/css");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(new[] { "file1.css", "file2.css" }));
-            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.css", "file2.css"]));
+            asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object> { { "fileprovider", fileProvider.Object } });
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
@@ -241,7 +241,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
 
-            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] linkTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
@@ -298,7 +298,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", absoluteUrl) };
 
-            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var hrefValue = tagHelperOutput.Attributes.First(x => x.Name == "href").Value;
@@ -353,12 +353,12 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
 
-            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             object hrefValue = tagHelperOutput.Attributes.First(x => x.Name == "href").Value;
             Assert.IsType(route.GetType(), hrefValue);
-            Assert.Contains(route.ToString(), hrefValue.ToString());
+            Assert.Contains(route.ToString()!, hrefValue.ToString());
         }
 
         [Fact2]
@@ -406,7 +406,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var relativeUrl = "/test.css";
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", relativeUrl) };
 
-            var tagHelperOutput = new TagHelperOutput("link", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             linkTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var hrefValue = tagHelperOutput.Attributes.First(x => x.Name == "href").Value;

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptTagHelperTest.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
@@ -66,8 +65,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/javascript");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(new []{"file.js"}));
-            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns([..new[] { "file.js" }]);
+            asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
             asset.Setup(a => a.GenerateCacheKey(It.IsAny<HttpContext>(), It.IsAny<IWebOptimizerOptions>()))
                 .Returns(cacheKey);
@@ -91,7 +90,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
             
-            var tagHelperOutput = new TagHelperOutput("script", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (_, _) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
@@ -159,7 +158,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var srcValue = $"{pathBase}/lib/bootstrap/dist/js/bootstrap.min.js";
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", srcValue) };
             
-            var tagHelperOutput = new TagHelperOutput("script", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (_, _) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
@@ -215,8 +214,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var asset = new Mock<IAsset>().SetupAllProperties();
             asset.SetupGet(a => a.ContentType).Returns("text/javascript");
             asset.SetupGet(a => a.Route).Returns(route);
-            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(new []{"file1.js", "file2.js"}));
-            asset.SetupGet(a => a.ExcludeFiles).Returns(new List<string>());
+            asset.SetupGet(a => a.SourceFiles).Returns(new List<string>(["file1.js", "file2.js"]));
+            asset.SetupGet(a => a.ExcludeFiles).Returns([]);
             asset.SetupGet(a => a.Items).Returns(new Dictionary<string, object>{ {"fileprovider", fileProvider.Object}});
             var assetObject = asset.Object;
             var assetPipeline = new Mock<IAssetPipeline>();
@@ -237,7 +236,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
             
-            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (_, _) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             string[] scriptTags = tagHelperOutput.PostElement.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
@@ -293,7 +292,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 "unique");
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", absoluteUrl) };
             
-            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (_, _) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var srcValue = tagHelperOutput.Attributes.First(x => x.Name == "src").Value;
@@ -345,7 +344,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
             var relativeUrl = "/test.js";
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", relativeUrl) };
             
-            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) =>  Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (_, _) =>  Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             var srcValue = tagHelperOutput.Attributes.First(x => x.Name == "src").Value;
@@ -399,7 +398,7 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", srcAttribute) };
 
-            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (useCachedResult, encoder) => Task.Factory.StartNew<TagHelperContent>(
+            var tagHelperOutput = new TagHelperOutput("scripts", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
                 () => new DefaultTagHelperContent()));
             scriptTagHelper.Process(tagHelperContext.Object, tagHelperOutput);
             object srcValue = tagHelperOutput.Attributes.First(x => x.Name == "src").Value;


### PR DESCRIPTION
1. Use CSharp collection initializer `[]` where possible
2. Use `Array.Empty<string>()` instead of `new string[0]` to avoid unnecessary allocations
3. Use `Assert.Single` and `Assert.Empty` where possible to improve error reporting in case test cases ever break
4. Remove unused `using` namespace statements
5. Use `(_, _)` for unused parameters in tests that require lambda functions e.g. TagHelperOutput tests
6. Add `readonly` access modifier where appropriate for private members that do not ever mutate state, thus enforcing immutable contracts
7. Use `new()` instead of `new TypeName()` to simplify constructor calls
8. Update Visual Studio sln file to use v17.x - I did not upgrade to slnx since it's not fully ready for prime time yet. Once it is, I will submit a PR to address. I think for the benefit of the community involvement, staying on sln is best until VS 2022 is updated appropriately.