### PR TITLE
Fix: Prevent ArgumentNullException when ILogger<Asset> is null

### DIFF
--- a/src/WebOptimizer.Core/AssetPipeline.cs
+++ b/src/WebOptimizer.Core/AssetPipeline.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WebOptimizer
 {
@@ -13,7 +14,7 @@ namespace WebOptimizer
         /// <summary>
         /// For use by the Asset constructor only. Do not use for logging messages inside <see cref="AssetPipeline"/>.
         /// </summary>
-        internal ILogger<Asset> _assetLogger;
+        internal ILogger<Asset> _assetLogger = NullLogger<Asset>.Instance;
         public IReadOnlyList<IAsset> Assets => _assets.Values.ToList();
 
         public bool TryGetAssetFromRoute(string route, out IAsset asset)


### PR DESCRIPTION
Addresses a `System.ArgumentNullException` that occurs when the `ILogger<Asset>` dependency is not resolved (i.e., passed as `null`) during service initialization.

Issue: https://github.com/ligershark/WebOptimizer/issues/371

**Problem:**

Users encounter an `ArgumentNullException` with the message "Value cannot be null. (Parameter 'logger')" originating from the `WebOptimizer.Asset` when the `ILogger<Asset>` parameter is `null`.

The stack trace often looks like this:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'logger')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at WebOptimizer.Asset..ctor(String route, String contentType, IEnumerable`1 sourceFiles, ILogger`1 logger)
   ... (rest of the stack trace)
```

**Solution:**

This change initializes the `_assetLogger` field within the `AssetPipeline` class with `NullLogger<Asset>.Instance`. This ensures that even if `ILogger<Asset>` is not explicitly provided or resolved when `Asset` instances are created, `_assetLogger` will never be `null`.

By providing a default "no-op" logger, any internal logging calls within `Asset` or related classes will execute without throwing a `NullReferenceException` or `ArgumentNullException`.

