### PR TITLE
Allow to use inline tag helpers without physical provider

### DIFF
--- a/src/WebOptimizer.Core/Taghelpers/LinkInlineHrefTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/LinkInlineHrefTagHelper.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
 namespace WebOptimizer.Taghelpers
@@ -92,11 +93,12 @@ namespace WebOptimizer.Taghelpers
             }
 
             string cleanRoute = route.TrimStart('~');
-            string file = HostingEnvironment.WebRootFileProvider.GetFileInfo(cleanRoute).PhysicalPath;
+            IFileInfo file = HostingEnvironment.WebRootFileProvider.GetFileInfo(cleanRoute);
 
-            if (File.Exists(file))
+            if (file.Exists)
             {
-                using (StreamReader reader = File.OpenText(file))
+                using (Stream stream = file.CreateReadStream())
+                using (StreamReader reader = new(stream))
                 {
                     content = await reader.ReadToEndAsync();
                     AddToCache(cacheKey, content, HostingEnvironment.WebRootFileProvider, cleanRoute);

--- a/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
+++ b/src/WebOptimizer.Core/Taghelpers/ScriptInlineSrcTagHelper.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 
 namespace WebOptimizer.Taghelpers
@@ -83,11 +84,12 @@ namespace WebOptimizer.Taghelpers
             }
 
             string cleanRoute = route.TrimStart('~');
-            string file = HostingEnvironment.WebRootFileProvider.GetFileInfo(cleanRoute).PhysicalPath;
+            IFileInfo file = HostingEnvironment.WebRootFileProvider.GetFileInfo(cleanRoute);
 
-            if (File.Exists(file))
+            if (file.Exists)
             {
-                using (StreamReader reader = File.OpenText(file))
+                using (Stream stream = file.CreateReadStream())
+                using (StreamReader reader = new(stream))
                 {
                     content = await reader.ReadToEndAsync();
                     AddToCache(cacheKey, content, HostingEnvironment.WebRootFileProvider, cleanRoute);

--- a/test/WebOptimizer.Core.Test/Mocks/MockChangeToken.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockChangeToken.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Extensions.Primitives;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    public class MockChangeToken : IChangeToken
+    {
+        public bool ActiveChangeCallbacks => false;
+
+        public bool HasChanged => false;
+
+        public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+        {
+            return NoopDisposable.Instance;
+        }
+
+        private class NoopDisposable : IDisposable
+        {
+            public static readonly NoopDisposable Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockDirectoryContents.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockDirectoryContents.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.FileProviders;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    public class MockDirectoryContents : IDirectoryContents
+    {
+        private readonly IEnumerable<IFileInfo> _files;
+
+        public MockDirectoryContents(IEnumerable<IFileInfo> files)
+        {
+            _files = files;
+        }
+
+        public bool Exists => true;
+
+        public IEnumerator<IFileInfo> GetEnumerator()
+        {
+            return _files.GetEnumerator();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _files.GetEnumerator();
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileInfo.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileInfo.cs
@@ -12,11 +12,28 @@ namespace WebOptimizer.Core.Test.Mocks
     {
         private readonly byte[] _data;
 
-        public MockFileInfo(string name, DateTimeOffset lastModified, byte[] data)
+        public MockFileInfo(string fileName, DateTimeOffset lastModified, byte[] data)
         {
             _data = data;
-            Name = name;
+            Name = fileName;
             LastModified = lastModified;
+        }
+
+        private MockFileInfo(string directoryName, DateTimeOffset lastModified, IList<MockFileInfo> files = null)
+        {
+            _data = null;
+            Name = directoryName;
+            LastModified = lastModified;
+            IsDirectory = true;
+            Files = files;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MockFileInfo"/> representing a directory.
+        /// </summary>
+        public static MockFileInfo CreateDirectory(string directoryName, DateTimeOffset lastModified, IList<MockFileInfo> files)
+        {
+            return new MockFileInfo(directoryName, lastModified, files);
         }
 
         public Stream CreateReadStream()
@@ -25,11 +42,12 @@ namespace WebOptimizer.Core.Test.Mocks
         }
 
         public bool Exists => true;
-        public bool IsDirectory => false;
+        public bool IsDirectory { get; }
         public DateTimeOffset LastModified { get; }
         public long Length => _data.Length;
         public string Name { get; }
         public string PhysicalPath => null;
+        public IList<MockFileInfo> Files {  get; }
     }
 
 }

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+namespace WebOptimizer.Core.Test.Mocks
+{
+    // grabbed the logic from https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
+    // and made it recursive
+    internal static class MockFileProvider
+    {
+        public static IFileProvider Create(MockFileInfo rootNode)
+        {
+            if (rootNode.Files == null || !rootNode.Files.Any())
+            {
+                throw new ArgumentException($"{nameof(rootNode)} must have children.", nameof(rootNode));
+            }
+
+            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
+            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>()))
+                .Returns((string p) => new NotFoundFileInfo(p));
+            SetupDirectoriesFiles(fileProvider, rootNode);
+            fileProvider.Setup(fp => fp.Watch(It.IsAny<string>()))
+                .Returns(new Mock<IChangeToken>().Object);
+
+            return fileProvider.Object;
+        }
+
+        private static void SetupDirectoriesFiles(Mock<IFileProvider> fileProviderMock, MockFileInfo directory)
+        {
+            var stack = new Stack<(MockFileInfo fileInfo, string directoryPath)>();
+            stack.Push((directory, string.Empty));
+
+            while (stack.Count > 0)
+            {
+                var (fileInfo, directoryPath) = stack.Pop();
+
+                if (fileInfo.IsDirectory)
+                {
+                    var children = fileInfo.Files;
+
+                    var directoryContents = new Mock<IDirectoryContents>();
+                    directoryContents.Setup(dc => dc.Exists).Returns(true);
+                    directoryContents.Setup(dc => dc.GetEnumerator())
+                        .Returns(() => children.GetEnumerator());
+                    directoryContents
+                        .As<IEnumerable>()
+                        .Setup(dc => dc.GetEnumerator())
+                        .Returns(() => children.GetEnumerator());
+
+                    var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
+
+                    fileProviderMock.Setup(fp => fp.GetDirectoryContents(fullPath))
+                        .Returns(directoryContents.Object);
+
+                    foreach (var child in children)
+                    {
+                        stack.Push((child, fullPath));
+                    }
+                }
+                else
+                {
+                    var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
+                    fileProviderMock.Setup(fp => fp.GetFileInfo(fullPath))
+                        .Returns(fileInfo);
+                    fileProviderMock.Setup(fp => fp.GetFileInfo("/" + fullPath))
+                        .Returns(fileInfo);
+                }
+            }
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
+++ b/test/WebOptimizer.Core.Test/Mocks/MockFileProvider.cs
@@ -1,17 +1,25 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
-using Moq;
 
 namespace WebOptimizer.Core.Test.Mocks
 {
     // grabbed the logic from https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
     // and made it recursive
-    internal static class MockFileProvider
+    internal class MockFileProvider : IFileProvider
     {
+        private readonly MockChangeToken _changeToken = new();
+        private readonly Dictionary<string, MockFileInfo> _files;
+        private readonly Dictionary<string, MockDirectoryContents> _directories;
+
+        private MockFileProvider(Dictionary<string, MockFileInfo> files, Dictionary<string, MockDirectoryContents> directories)
+        {
+            _files = files;
+            _directories = directories;
+        }
+
         public static IFileProvider Create(MockFileInfo rootNode)
         {
             if (rootNode.Files == null || !rootNode.Files.Any())
@@ -19,20 +27,11 @@ namespace WebOptimizer.Core.Test.Mocks
                 throw new ArgumentException($"{nameof(rootNode)} must have children.", nameof(rootNode));
             }
 
-            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
-            fileProvider.Setup(fp => fp.GetFileInfo(It.IsAny<string>()))
-                .Returns((string p) => new NotFoundFileInfo(p));
-            SetupDirectoriesFiles(fileProvider, rootNode);
-            fileProvider.Setup(fp => fp.Watch(It.IsAny<string>()))
-                .Returns(new Mock<IChangeToken>().Object);
+            Dictionary<string, MockFileInfo> files = [];
+            Dictionary<string, MockDirectoryContents> directories = [];
 
-            return fileProvider.Object;
-        }
-
-        private static void SetupDirectoriesFiles(Mock<IFileProvider> fileProviderMock, MockFileInfo directory)
-        {
             var stack = new Stack<(MockFileInfo fileInfo, string directoryPath)>();
-            stack.Push((directory, string.Empty));
+            stack.Push((rootNode, string.Empty));
 
             while (stack.Count > 0)
             {
@@ -42,19 +41,9 @@ namespace WebOptimizer.Core.Test.Mocks
                 {
                     var children = fileInfo.Files;
 
-                    var directoryContents = new Mock<IDirectoryContents>();
-                    directoryContents.Setup(dc => dc.Exists).Returns(true);
-                    directoryContents.Setup(dc => dc.GetEnumerator())
-                        .Returns(() => children.GetEnumerator());
-                    directoryContents
-                        .As<IEnumerable>()
-                        .Setup(dc => dc.GetEnumerator())
-                        .Returns(() => children.GetEnumerator());
-
                     var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
 
-                    fileProviderMock.Setup(fp => fp.GetDirectoryContents(fullPath))
-                        .Returns(directoryContents.Object);
+                    directories[fullPath] = new MockDirectoryContents(children);
 
                     foreach (var child in children)
                     {
@@ -64,12 +53,27 @@ namespace WebOptimizer.Core.Test.Mocks
                 else
                 {
                     var fullPath = string.IsNullOrEmpty(directoryPath) ? fileInfo.Name : directoryPath + "/" + fileInfo.Name;
-                    fileProviderMock.Setup(fp => fp.GetFileInfo(fullPath))
-                        .Returns(fileInfo);
-                    fileProviderMock.Setup(fp => fp.GetFileInfo("/" + fullPath))
-                        .Returns(fileInfo);
+                    files[fullPath] = fileInfo;
+                    files["/" + fullPath] = fileInfo;
                 }
             }
+
+            return new MockFileProvider(files, directories);
+        }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            return _files.TryGetValue(subpath, out var fileInfo) ? fileInfo : new NotFoundFileInfo(subpath);
+        }
+
+        public IDirectoryContents GetDirectoryContents(string subpath)
+        {
+           return _directories.TryGetValue(subpath, out var directoryContents) ? directoryContents : new NotFoundDirectoryContents();
+        }
+
+        public IChangeToken Watch(string filter)
+        {
+            return _changeToken;
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkInlineHrefTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkInlineHrefTagHelperTest.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Moq;
+using WebOptimizer.Core.Test.Mocks;
+using WebOptimizer.Taghelpers;
+using Xunit;
+
+namespace WebOptimizer.Core.Test.TagHelpers
+{
+    public class LinkInlineHrefTagHelperTest
+    {
+        /// <summary>
+        /// Tests that <see cref="LinkInlineHrefTagHelper"/> inlines the file content read through
+        /// <see cref="IFileInfo.CreateReadStream"/>, even when the file provider exposes no
+        /// <see cref="IFileInfo.PhysicalPath"/> (e.g. embedded or composite providers).
+        /// </summary>
+        [Fact2]
+        public async Task InlineHref_FileProviderWithoutPhysicalPath_InlinesContent()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var content = "body { background-color: red; }";
+            var root =
+                MockFileInfo.CreateDirectory("", date,
+                [
+                    new MockFileInfo("test.css", date, Encoding.UTF8.GetBytes(content)),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+            var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                .Returns((object key) =>
+                {
+                    var cacheEntry = new Mock<ICacheEntry>();
+                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                    return cacheEntry.Object;
+                });
+
+            var options = new WebOptimizerOptions();
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/test.css";
+            IAsset asset;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+            var linkTagHelper = new LinkInlineHrefTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+            };
+            linkTagHelper.ViewContext = viewContext;
+            linkTagHelper.Href = route;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "link",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
+
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            await linkTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput);
+
+            Assert.Equal("style", tagHelperOutput.TagName);
+            Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
+            Assert.Equal(content, tagHelperOutput.Content.GetContent());
+        }
+
+        /// <summary>
+        /// Same scenario as <see cref="InlineHref_FileProviderWithoutPhysicalPath_InlinesContent"/> but
+        /// backed by a real <see cref="PhysicalFileProvider"/> over a temporary directory tree
+        /// instead of a mocked file provider.
+        /// </summary>
+        [Fact2]
+        public async Task InlineHref_PhysicalFileProvider_InlinesContent()
+        {
+            var content = "body { background-color: red; }";
+            string rootPath = Path.Combine(Path.GetTempPath(), "WebOptimizerTest_" + Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                Directory.CreateDirectory(rootPath);
+                File.WriteAllText(Path.Combine(rootPath, "test.css"), content);
+
+                var fileProvider = new PhysicalFileProvider(rootPath);
+
+                var env = new Mock<IWebHostEnvironment>();
+                env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+                var cache = new Mock<IMemoryCache>();
+                cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                    .Returns((object key) =>
+                    {
+                        var cacheEntry = new Mock<ICacheEntry>();
+                        cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                        return cacheEntry.Object;
+                    });
+
+                var options = new WebOptimizerOptions();
+                var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+                optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+                var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+                var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+                var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+                optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+                var route = "/test.css";
+                IAsset asset;
+                var assetPipeline = new Mock<IAssetPipeline>();
+                assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+                var linkTagHelper = new LinkInlineHrefTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+                var viewContext = new ViewContext
+                {
+                    HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+                };
+                linkTagHelper.ViewContext = viewContext;
+                linkTagHelper.Href = route;
+
+                var tagHelperContext = new Mock<TagHelperContext>(
+                    "link",
+                    new TagHelperAttributeList(),
+                    new Dictionary<object, object>(),
+                    "unique");
+                var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
+
+                var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                    () => new DefaultTagHelperContent()));
+                await linkTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput);
+
+                Assert.Equal("style", tagHelperOutput.TagName);
+                Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
+                Assert.Equal(content, tagHelperOutput.Content.GetContent());
+            }
+            finally
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="LinkInlineHrefTagHelper"/> throws a <see cref="FileNotFoundException"/>
+        /// when the referenced file does not exist in the file provider.
+        /// </summary>
+        [Fact2]
+        public async Task InlineHref_FileDoesNotExist_ThrowsFileNotFound()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root =
+                MockFileInfo.CreateDirectory("", date,
+                [
+                    new MockFileInfo("test.css", date, Encoding.UTF8.GetBytes("body { }")),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+
+            var options = new WebOptimizerOptions();
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/missing.css";
+            IAsset asset;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+            var linkTagHelper = new LinkInlineHrefTagHelper(env.Object, new Mock<IMemoryCache>().Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+            };
+            linkTagHelper.ViewContext = viewContext;
+            linkTagHelper.Href = route;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "link",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("href", route) };
+
+            var tagHelperOutput = new TagHelperOutput("link", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+
+            await Assert.ThrowsAsync<FileNotFoundException>(
+                () => linkTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput));
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/TagHelpers/LinkInlineHrefTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/LinkInlineHrefTagHelperTest.cs
@@ -49,14 +49,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 });
 
             var options = new WebOptimizerOptions();
-            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+            optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
             var route = "/test.css";
             IAsset asset;
@@ -85,6 +79,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             Assert.Equal("style", tagHelperOutput.TagName);
             Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
             Assert.Equal(content, tagHelperOutput.Content.GetContent());
+
+            Mock.VerifyAll(env, cache, assetPipeline);
         }
 
         /// <summary>
@@ -118,14 +114,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
                     });
 
                 var options = new WebOptimizerOptions();
-                var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-                optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-                var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-                var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-                var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-                optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+                var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+                optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
                 var route = "/test.css";
                 IAsset asset;
@@ -154,6 +144,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 Assert.Equal("style", tagHelperOutput.TagName);
                 Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
                 Assert.Equal(content, tagHelperOutput.Content.GetContent());
+
+                Mock.VerifyAll(cache, assetPipeline, env);
             }
             finally
             {
@@ -183,14 +175,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
 
             var options = new WebOptimizerOptions();
-            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+            optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
             var route = "/missing.css";
             IAsset asset;
@@ -217,6 +203,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             await Assert.ThrowsAsync<FileNotFoundException>(
                 () => linkTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput));
+
+            Mock.VerifyAll(env, assetPipeline);
         }
     }
 }

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptInlineSrcTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptInlineSrcTagHelperTest.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Moq;
+using WebOptimizer.Core.Test.Mocks;
+using WebOptimizer.Taghelpers;
+using Xunit;
+
+namespace WebOptimizer.Core.Test.TagHelpers
+{
+    public class ScriptInlineSrcTagHelperTest
+    {
+        /// <summary>
+        /// Tests that <see cref="ScriptInlineSrcTagHelper"/> inlines the file content read through
+        /// <see cref="IFileInfo.CreateReadStream"/>, even when the file provider exposes no
+        /// <see cref="IFileInfo.PhysicalPath"/> (e.g. embedded or composite providers).
+        /// </summary>
+        [Fact2]
+        public async Task InlineSrc_FileProviderWithoutPhysicalPath_InlinesContent()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var content = "console.log('hello');";
+            var root =
+                MockFileInfo.CreateDirectory("", date,
+                [
+                    new MockFileInfo("test.js", date, Encoding.UTF8.GetBytes(content)),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+            var cache = new Mock<IMemoryCache>();
+            cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                .Returns((object key) =>
+                {
+                    var cacheEntry = new Mock<ICacheEntry>();
+                    cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                    return cacheEntry.Object;
+                });
+
+            var options = new WebOptimizerOptions();
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/test.js";
+            IAsset asset;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+            var scriptTagHelper = new ScriptInlineSrcTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+            };
+            scriptTagHelper.ViewContext = viewContext;
+            scriptTagHelper.Src = route;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "script",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
+
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+            await scriptTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput);
+
+            Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
+            Assert.Equal(content, tagHelperOutput.Content.GetContent());
+        }
+
+        /// <summary>
+        /// Same scenario as <see cref="InlineSrc_FileProviderWithoutPhysicalPath_InlinesContent"/> but
+        /// backed by a real <see cref="PhysicalFileProvider"/> over a temporary directory tree
+        /// instead of a mocked file provider.
+        /// </summary>
+        [Fact2]
+        public async Task InlineSrc_PhysicalFileProvider_InlinesContent()
+        {
+            var content = "console.log('hello');";
+            string rootPath = Path.Combine(Path.GetTempPath(), "WebOptimizerTest_" + Guid.NewGuid().ToString("N"));
+
+            try
+            {
+                Directory.CreateDirectory(rootPath);
+                File.WriteAllText(Path.Combine(rootPath, "test.js"), content);
+
+                var fileProvider = new PhysicalFileProvider(rootPath);
+
+                var env = new Mock<IWebHostEnvironment>();
+                env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+                var cache = new Mock<IMemoryCache>();
+                cache.Setup(c => c.CreateEntry(It.IsAny<object>()))
+                    .Returns((object key) =>
+                    {
+                        var cacheEntry = new Mock<ICacheEntry>();
+                        cacheEntry.Setup(ce => ce.ExpirationTokens).Returns([]);
+
+                        return cacheEntry.Object;
+                    });
+
+                var options = new WebOptimizerOptions();
+                var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+                optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+                var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+                var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+                var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+                optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+                var route = "/test.js";
+                IAsset asset;
+                var assetPipeline = new Mock<IAssetPipeline>();
+                assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+                var scriptTagHelper = new ScriptInlineSrcTagHelper(env.Object, cache.Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+                var viewContext = new ViewContext
+                {
+                    HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+                };
+                scriptTagHelper.ViewContext = viewContext;
+                scriptTagHelper.Src = route;
+
+                var tagHelperContext = new Mock<TagHelperContext>(
+                    "script",
+                    new TagHelperAttributeList(),
+                    new Dictionary<object, object>(),
+                    "unique");
+                var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
+
+                var tagHelperOutput = new TagHelperOutput("script", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                    () => new DefaultTagHelperContent()));
+                await scriptTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput);
+
+                Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
+                Assert.Equal(content, tagHelperOutput.Content.GetContent());
+            }
+            finally
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, recursive: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ScriptInlineSrcTagHelper"/> throws a <see cref="FileNotFoundException"/>
+        /// when the referenced file does not exist in the file provider.
+        /// </summary>
+        [Fact2]
+        public async Task InlineSrc_FileDoesNotExist_ThrowsFileNotFound()
+        {
+            var date = new DateTime(2017, 1, 1);
+            var root =
+                MockFileInfo.CreateDirectory("", date,
+                [
+                    new MockFileInfo("test.js", date, Encoding.UTF8.GetBytes("var x = 1;")),
+                ]);
+            var fileProvider = MockFileProvider.Create(root);
+
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
+
+            var options = new WebOptimizerOptions();
+            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
+            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
+
+            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
+            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
+
+            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
+            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+
+            var route = "/missing.js";
+            IAsset asset;
+            var assetPipeline = new Mock<IAssetPipeline>();
+            assetPipeline.Setup(ap => ap.TryGetAssetFromRoute(It.IsAny<string>(), out asset)).Returns(false);
+
+            var scriptTagHelper = new ScriptInlineSrcTagHelper(env.Object, new Mock<IMemoryCache>().Object, assetPipeline.Object, optionsMonitor.Object, new Mock<IAssetBuilder>().Object);
+            var viewContext = new ViewContext
+            {
+                HttpContext = new Mock<HttpContext>().SetupAllProperties().Object
+            };
+            scriptTagHelper.ViewContext = viewContext;
+            scriptTagHelper.Src = route;
+
+            var tagHelperContext = new Mock<TagHelperContext>(
+                "script",
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "unique");
+            var attributes = new TagHelperAttributeList { new TagHelperAttribute("src", route) };
+
+            var tagHelperOutput = new TagHelperOutput("script", attributes, (_, _) => Task.Factory.StartNew<TagHelperContent>(
+                () => new DefaultTagHelperContent()));
+
+            await Assert.ThrowsAsync<FileNotFoundException>(
+                () => scriptTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput));
+        }
+    }
+}

--- a/test/WebOptimizer.Core.Test/TagHelpers/ScriptInlineSrcTagHelperTest.cs
+++ b/test/WebOptimizer.Core.Test/TagHelpers/ScriptInlineSrcTagHelperTest.cs
@@ -49,14 +49,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
                 });
 
             var options = new WebOptimizerOptions();
-            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+            optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
             var route = "/test.js";
             IAsset asset;
@@ -84,6 +78,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
             Assert.Equal(content, tagHelperOutput.Content.GetContent());
+
+            Mock.VerifyAll(env, cache, assetPipeline);
         }
 
         /// <summary>
@@ -117,14 +113,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
                     });
 
                 var options = new WebOptimizerOptions();
-                var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-                optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-                var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-                var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-                var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-                optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+                var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+                optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
                 var route = "/test.js";
                 IAsset asset;
@@ -152,6 +142,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
                 Assert.Equal(TagMode.StartTagAndEndTag, tagHelperOutput.TagMode);
                 Assert.Equal(content, tagHelperOutput.Content.GetContent());
+
+                Mock.VerifyAll(cache, assetPipeline, env);
             }
             finally
             {
@@ -181,14 +173,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
             env.Setup(e => e.WebRootFileProvider).Returns(fileProvider);
 
             var options = new WebOptimizerOptions();
-            var optionsFactory = new Mock<IOptionsFactory<WebOptimizerOptions>>();
-            optionsFactory.Setup(x => x.Create(It.IsAny<string>())).Returns(options);
-
-            var sources = new List<IOptionsChangeTokenSource<WebOptimizerOptions>>();
-            var optionsMonitorCache = new Mock<IOptionsMonitorCache<WebOptimizerOptions>>();
-
-            var optionsMonitor = new Mock<OptionsMonitor<WebOptimizerOptions>>(optionsFactory.Object, sources, optionsMonitorCache.Object);
-            optionsMonitor.Setup(x => x.Get(It.IsAny<string>())).Returns(options);
+            var optionsMonitor = new Mock<IOptionsMonitor<WebOptimizerOptions>>();
+            optionsMonitor.Setup(x => x.CurrentValue).Returns(options);
 
             var route = "/missing.js";
             IAsset asset;
@@ -215,6 +201,8 @@ namespace WebOptimizer.Core.Test.TagHelpers
 
             await Assert.ThrowsAsync<FileNotFoundException>(
                 () => scriptTagHelper.ProcessAsync(tagHelperContext.Object, tagHelperOutput));
+
+            Mock.VerifyAll(env, assetPipeline);
         }
     }
 }


### PR DESCRIPTION
I found out that inline tag helpers rely on physical paths. IFileInfo can return the read stream, so no need to use the regular file stream instead of `CreateReadStream`.

They will work with other providers, e.g. [ManifestEmbeddedFileProvider](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.fileproviders.manifestembeddedfileprovider).